### PR TITLE
Fix #9 add Handlebars as a template engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is a demo project, which accompanied my ["Shoot-out! Template engines for t
 * [Jade](https://github.com/neuland/jade4j) - v0.4.2
 * [HTTL](http://httl.github.io/en/) - v1.0.11
 * [Pebble] (http://www.mitchellbosecke.com/pebble/home) - v1.4.5
+* [Handlebars] (https://github.com/jknack/handlebars.java) - v2.2.2
 
 
 ## Build and run
@@ -35,6 +36,7 @@ See the demo URLs:
   - http://localhost:8080/scalate
   - http://localhost:8080/mustache
   - http://localhost:8080/pebble
+  - http://localhost:8080/handlebars
   
 ## Benchmarking
 
@@ -48,6 +50,7 @@ You can try any of the following URLs.
     $ ab -n 10000 -c 10 http://localhost:8080/mustache
     $ ab -n 10000 -c 10 http://localhost:8080/jade
     $ ab -n 10000 -c 10 http://localhost:8080/pebble
+    $ ab -n 10000 -c 10 http://localhost:8080/handlebars
 
 
 For creating the below benchmark results I used ApacheBench(Version 2.3) with the following settings:

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <spring-rythm.version>1.0</spring-rythm.version>
     <pebble-spring3.version>1.4.5</pebble-spring3.version>
     <mustache-spring-view.version>1.2</mustache-spring-view.version>
+    <handlebars.version>2.2.2</handlebars.version>
   </properties>
 
   <dependencies>
@@ -185,6 +186,12 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.6.6</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.jknack</groupId>
+      <artifactId>handlebars-springmvc</artifactId>
+      <version>${handlebars.version}</version>
     </dependency>
 
     <!-- Test -->

--- a/src/main/webapp/WEB-INF/handlebars/head.hbs
+++ b/src/main/webapp/WEB-INF/handlebars/head.hbs
@@ -1,0 +1,7 @@
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
+    <title>{{i18n "example.title"}} - Mustache</title>
+    <link rel="stylesheet" href="/webjars/bootstrap/3.0.1/css/bootstrap.min.css"/>
+</head>

--- a/src/main/webapp/WEB-INF/handlebars/index-handlebars.hbs
+++ b/src/main/webapp/WEB-INF/handlebars/index-handlebars.hbs
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+    {{>head}}
+    <body>
+        <div class="container">
+            <div class="page-header">
+                <h1>{{i18n "example.title"}} - Handlebars</h1>
+            </div>
+            {{#presentations}}
+                {{>presentation}}
+            {{/presentations}}
+        </div>
+        {{>scripts}}
+    </body>
+</html>

--- a/src/main/webapp/WEB-INF/handlebars/presentation.hbs
+++ b/src/main/webapp/WEB-INF/handlebars/presentation.hbs
@@ -1,0 +1,8 @@
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">{{title}} - {{speakerName}}</h3>
+    </div>
+    <div class="panel-body">
+        {{{summary}}}
+    </div>
+</div>

--- a/src/main/webapp/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/src/main/webapp/WEB-INF/mvc-dispatcher-servlet.xml
@@ -157,10 +157,19 @@
   </bean>
 
   <bean id="pebbleViewResolver" class="com.mitchellbosecke.pebble.spring.PebbleViewResolver">
+    <property name="viewNames" value="*-pebble"/>
     <property name="prefix" value="/WEB-INF/pebble/" />
     <property name="suffix" value=".html" />
     <property name="order" value="10"/>
     <property name="pebbleEngine" ref="pebbleEngine" />
+  </bean>
+
+  <!-- Handlebars -->
+  <bean id="handlebarsViewResolver" class="com.github.jknack.handlebars.springmvc.HandlebarsViewResolver">
+    <property name="viewNames" value="*-handlebars"/>
+    <property name="prefix" value="/WEB-INF/handlebars/"/>
+    <property name="suffix" value=".hbs"/>
+    <property name="order" value="11"/>
   </bean>
 
   <bean id="localeResolver"


### PR DESCRIPTION
This fixes #9 by adding Handlebars as a template engine. I updated the readme with the new links for Handlebars but I did not update the benchmark section as my development machine specs are quite a bit different. The handlebars templates are copies of the mustache templates with a slight change for how Handlebars does i18n.