### PR TITLE
Add HtmlFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,17 @@ This is a demo project, which accompanied my ["Shoot-out! Template engines for t
 * Mustache - Based on [JMustache](https://github.com/samskivert/jmustache) - v1.13
 * [Scalate](http://scalate.fusesource.org/)  - v1.7.1
 * [Jade](https://github.com/neuland/jade4j) - v1.2.5
-* [HTTL](http://httl.github.io/en/) - v1.0.11
 * [Pebble](http://www.mitchellbosecke.com/pebble/home) - v2.2.3
 * [Handlebars](https://github.com/jknack/handlebars.java) - v4.0.6
 * [jtwig](https://github.com/jtwig/jtwig) - v3.1.1
 * [chunk](https://github.com/tomj74/chunk-templates) - v3.2.4
-
+* [Rocker](https://github.com/fizzed/rocker) - 1.1.0
+* [j2Html](https://j2html.com/) - v1.3.0
+* [KotlinX Html](https://github.com/Kotlin/kotlinx.html) - v0.6.11
+* [HtmlFlow](https://github.com/xmlet/HtmlFlow) - v3.2
 
 ## Build and run
-You need Java 7 and Maven 3 to build and run this project.
+You need Java 8 (or higher) and Maven 3 to build and run this project.
 Build the project with
 
     mvn package
@@ -41,6 +43,10 @@ See the demo URLs:
   - http://localhost:8080/handlebars
   - http://localhost:8080/jtwig
   - http://localhost:8080/chunk
+  - http://localhost:8080/rocker
+  - http://localhost:8080/j2html
+  - http://localhost:8080/kotlinhtml
+  - http://localhost:8080/htmlFlow
 
 ## Benchmarking
 
@@ -57,7 +63,10 @@ You can try any of the following URLs.
     $ ab -n 10000 -c 10 http://localhost:8080/handlebars
     $ ab -n 10000 -c 10 http://localhost:8080/jtwig
     $ ab -n 10000 -c 10 http://localhost:8080/chunk
-
+    $ ab -n 10000 -c 10 http://localhost:8080/rocker
+    $ ab -n 10000 -c 10 http://localhost:8080/j2html
+    $ ab -n 10000 -c 10 http://localhost:8080/kotlinhtml
+    $ ab -n 10000 -c 10 http://localhost:8080/htmlFlow
 
 For creating the below benchmark results I used ApacheBench(Version 2.3) with the following settings:
 
@@ -67,34 +76,39 @@ ab -n 25000 -c 25 -k http://localhost:8080/jsp
 With 25 concurrent requests and 25.000 requests in total this resulted in the following numbers:
 
 
-## Benchmarks 2015
+## Benchmarks 2018
 
 These tests were done on a local machine with the following specs:
 
 ```
-Mac OS X Version 10.11.1
-2,3 GHz Intel Core i7 Quad core
-ava(TM) SE Runtime Environment (build 1.8.0_51-b16)
-Java HotSpot(TM) 64-Bit Server VM (build 25.51-b03, mixed mode)
+Microsoft Windows 10 Education  OS Version: 10.0.17134 N/A Build 17134
+Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz, 2808 Mhz, 4 Core(s), 8 Logical Processor(s)
+Java(TM) SE Runtime Environment 18.9 (build 11+28)
+Java HotSpot(TM) 64-Bit Server VM 18.9 (build 11+28, mixed mode)
 Apache Tomcat 7.0.53 with 512M RAM
 ```
 
-Results in order (high to low):
+Results in order (low to high):
 
-Total time taken for processing 25.000 requests with a concurrency level of 25. (lower is better)
+Total time taken for processing 25.000 requests with a concurrency level of 25. (**lower is better**)
 
 ```
-jTwig                   4.709 seconds
-Thymeleaf               4.147 seconds
-Scalate - Scaml         3.479 seconds
-Handlebars              2.936 seconds
-Jade4j                  2.735 seconds
-Freemarker              2.637 seconds
-HTTL                    2.531 seconds
-Pebble                  2.512 seconds
-Velocity                2.491 seconds
-Mustache (JMustache)    2.326 seconds
-JSP                     2.227 seconds
+HtmlFlow	1.172 seconds
+Rocker		1.299 seconds
+Jade		3.071 seconds
+Mustache	3.098 seconds
+Pebble		3.172 seconds
+Freemarker	3.224 seconds
+Velocity	3.283 seconds
+Chunk		3.334 seconds
+Jtwig		3.399 seconds
+JSP		3.424 seconds
+Thymeleaf	3.645 seconds
+Handlebars	3.765 seconds
+J2Html		4.561 seconds
+Kotlin		6.111 seconds
+Scalate		7.880 seconds
+
 ```
 
 *Keep in mind that in the real world, these results will differ depending on the complexity of the templates, hardware, etc, so it's just an indication and if you want to know the truth you will have to run the benchmark yourself to see how such a template engine performs in your specific environment.*

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,10 @@
         <spring-jade4j.version>1.2.5</spring-jade4j.version>
         <chunk.version>3.2.4</chunk.version>
         <chunk-springmvc.version>0.1.0</chunk-springmvc.version>
+
+        <rocker.version>1.1.0</rocker.version>
+        <kotlin.version>1.2.61</kotlin.version>
+        <kotlinx.html.version>0.6.11</kotlinx.html.version>
     </properties>
 
     <parent>
@@ -261,6 +265,30 @@
             <version>2.2.3</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.j2html</groupId>
+            <artifactId>j2html</artifactId>
+            <version>1.3.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-html-jvm</artifactId>
+            <version>${kotlinx.html.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fizzed</groupId>
+            <artifactId>rocker-runtime</artifactId>
+            <version>${rocker.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -287,6 +315,43 @@
                         <goals>
                             <goal>execute</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.fizzed</groupId>
+                <artifactId>rocker-maven-plugin</artifactId>
+                <version>${rocker.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-rocker-templates</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <templateDirectory>src/main/resources</templateDirectory>
+                            <javaVersion>1.8</javaVersion>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,11 @@
             <artifactId>spring-jade4j</artifactId>
             <version>${spring-jade4j.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.github.xmlet</groupId>
+            <artifactId>htmlflow</artifactId>
+            <version>3.2</version>
+        </dependency>
         <!--<dependency>-->
         <!--<groupId>com.googlecode.concurrentlinkedhashmap</groupId>-->
         <!--<artifactId>concurrentlinkedhashmap-lru</artifactId>-->

--- a/src/main/java/com/jeroenreijn/examples/factory/HtmlFlowViewFactory.java
+++ b/src/main/java/com/jeroenreijn/examples/factory/HtmlFlowViewFactory.java
@@ -1,0 +1,43 @@
+package com.jeroenreijn.examples.factory;
+
+import com.jeroenreijn.examples.model.Presentation;
+import com.jeroenreijn.examples.view.IndexHtmlFlow;
+import org.springframework.web.servlet.view.AbstractTemplateView;
+import org.springframework.web.servlet.view.AbstractTemplateViewResolver;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+import java.util.Map;
+
+public class HtmlFlowViewFactory extends AbstractTemplateViewResolver {
+
+    public HtmlFlowViewFactory() {
+        this.setViewClass(this.requiredViewClass());
+    }
+
+    @Override
+    protected Class<?> requiredViewClass() {
+        return HtmlFlowView.class;
+    }
+
+    public static class HtmlFlowView extends AbstractTemplateView {
+        @Override
+        protected void renderMergedTemplateModel(
+            Map<String, Object> map,
+            HttpServletRequest req,
+            HttpServletResponse res) throws Exception
+        {
+            String html = IndexHtmlFlow
+                .view
+                .render(map);
+            // Headers
+            res.setContentLength(html.length());
+            res.setContentType("text/html");
+            // Send body
+            PrintWriter writer = res.getWriter();
+            writer.write(html);
+            writer.flush();
+        }
+    }
+}

--- a/src/main/java/com/jeroenreijn/examples/factory/J2HtmlViewFactory.java
+++ b/src/main/java/com/jeroenreijn/examples/factory/J2HtmlViewFactory.java
@@ -1,0 +1,80 @@
+package com.jeroenreijn.examples.factory;
+
+import com.jeroenreijn.examples.model.Presentation;
+import org.springframework.web.servlet.view.AbstractTemplateView;
+import org.springframework.web.servlet.view.AbstractTemplateViewResolver;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static j2html.TagCreator.*;
+import j2html.attributes.Attribute;
+
+public class J2HtmlViewFactory extends AbstractTemplateViewResolver {
+
+    public J2HtmlViewFactory() {
+        this.setViewClass(this.requiredViewClass());
+    }
+
+    @Override
+    protected Class<?> requiredViewClass() {
+        return J2HtmlViewFactory.J2HtmlView.class;
+    }
+
+    public static class J2HtmlView extends AbstractTemplateView {
+
+        private String HEADER = "<!DOCTYPE html>";
+
+        @Override
+        protected void renderMergedTemplateModel(
+                Map<String, Object> map,
+                HttpServletRequest req,
+                HttpServletResponse res) throws Exception
+        {
+            Collection<Presentation> presentations = (Collection<Presentation>) map.get("presentations");
+
+            String html = render(presentations);
+
+            // Headers
+            res.setContentLength(html.length());
+            res.setContentType("text/html");
+            // Send body
+            PrintWriter writer = res.getWriter();
+            writer.write(html);
+            writer.flush();
+        }
+
+        String render(Collection<Presentation> presentations){
+            return HEADER + html(
+                    head(
+                            meta().withCharset("utf-8"),
+                            meta().withName("viewport").withContent("width=device-width, initial-scale=1.0"),
+                            meta().attr(new Attribute("http-equiv", "Content-Language")).withContent("IE=Edge"),
+                            title("JFall 2013 Presentations - htmlApi"),
+                            link().withRel("Stylesheet").withHref("/webjars/bootstrap/3.3.7-1/css/bootstrap.min.css").attr(new Attribute("media", "screen"))
+                    ),
+                    body(
+                            div(
+                                    div(
+                                            h1("JFall 2013 Presentations - J2Html")
+                                    ).withClass("page-header"),
+                                    each(presentations, (Presentation presentation) ->
+                                            div(
+                                                    div(
+                                                            h3(presentation.getTitle() + " - " + presentation.getSpeakerName()).withClass("panel-title")
+                                                    ).withClass("panel-heading"),
+                                                    div(presentation.getSummary()).withClass("panel-body")
+                                            ).withClass("panel panel-default")
+                                    )
+                            ).withClass("container"),
+                            script().withSrc("/webjars/jquery/3.1.1/jquery.min.js"),
+                            script().withSrc("/webjars/bootstrap/3.3.7-1/js/bootstrap.min.js")
+                    )
+            ).renderFormatted();
+        }
+    }
+}

--- a/src/main/java/com/jeroenreijn/examples/factory/KotlinHtmlViewFactory.java
+++ b/src/main/java/com/jeroenreijn/examples/factory/KotlinHtmlViewFactory.java
@@ -1,0 +1,46 @@
+package com.jeroenreijn.examples.factory;
+
+import com.jeroenreijn.examples.model.Presentation;
+import com.jeroenreijn.examples.view.PresentationsKotlin;
+import org.springframework.web.servlet.view.AbstractTemplateView;
+import org.springframework.web.servlet.view.AbstractTemplateViewResolver;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.Map;
+
+public class KotlinHtmlViewFactory extends AbstractTemplateViewResolver {
+
+    public KotlinHtmlViewFactory() {
+        this.setViewClass(this.requiredViewClass());
+    }
+
+    @Override
+    protected Class<?> requiredViewClass() {
+        return KotlinHtmlViewFactory.KotlinHtmlView.class;
+    }
+
+    public static class KotlinHtmlView extends AbstractTemplateView {
+
+        @Override
+        protected void renderMergedTemplateModel(
+                Map<String, Object> map,
+                HttpServletRequest req,
+                HttpServletResponse res) throws Exception
+        {
+            Collection<Presentation> presentations = (Collection<Presentation>) map.get("presentations");
+
+            String html = PresentationsKotlin.Companion.presentationsTemplate(presentations);
+
+            // Headers
+            res.setContentLength(html.length());
+            res.setContentType("text/html");
+            // Send body
+            PrintWriter writer = res.getWriter();
+            writer.write(html);
+            writer.flush();
+        }
+    }
+}

--- a/src/main/java/com/jeroenreijn/examples/factory/RockerViewFactory.java
+++ b/src/main/java/com/jeroenreijn/examples/factory/RockerViewFactory.java
@@ -1,0 +1,53 @@
+package com.jeroenreijn.examples.factory;
+
+import com.jeroenreijn.examples.model.Presentation;
+import com.jeroenreijn.examples.view.PresentationsKotlin;
+import org.springframework.web.servlet.view.AbstractTemplateView;
+import org.springframework.web.servlet.view.AbstractTemplateViewResolver;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.Map;
+
+public class RockerViewFactory extends AbstractTemplateViewResolver {
+
+    public RockerViewFactory() {
+        this.setViewClass(this.requiredViewClass());
+    }
+
+    @Override
+    protected Class<?> requiredViewClass() {
+        return RockerViewFactory.RockerView.class;
+    }
+
+    public static class RockerView extends AbstractTemplateView {
+
+        @Override
+        protected void renderMergedTemplateModel(
+                Map<String, Object> map,
+                HttpServletRequest req,
+                HttpServletResponse res) throws Exception
+        {
+            Collection<Presentation> presentations = (Collection<Presentation>) map.get("presentations");
+
+            String html = renderPresentations(presentations);
+
+            // Headers
+            res.setContentLength(html.length());
+            res.setContentType("text/html");
+            // Send body
+            PrintWriter writer = res.getWriter();
+            writer.write(html);
+            writer.flush();
+        }
+
+        String renderPresentations(Collection<Presentation> presentations){
+            return templates.presentations
+                    .template(presentations)
+                    .render()
+                    .toString();
+        }
+    }
+}

--- a/src/main/java/com/jeroenreijn/examples/view/IndexHtmlFlow.java
+++ b/src/main/java/com/jeroenreijn/examples/view/IndexHtmlFlow.java
@@ -1,0 +1,71 @@
+package com.jeroenreijn.examples.view;
+
+import com.jeroenreijn.examples.model.Presentation;
+import htmlflow.DynamicHtml;
+import htmlflow.HtmlView;
+import org.springframework.web.servlet.support.RequestContext;
+import org.xmlet.htmlapifaster.EnumMediaType;
+import org.xmlet.htmlapifaster.EnumRelType;
+
+import java.util.Map;
+
+public class IndexHtmlFlow {
+    public static final HtmlView<Map<String, Object>> view =
+        DynamicHtml
+            .view(IndexHtmlFlow::templatePresentations)
+            .threadSafe();
+
+    private static void templatePresentations(
+        DynamicHtml<Map<String, Object>> view,
+        Map<String, Object> map)
+    {
+        Iterable<Presentation> presentations = (Iterable<Presentation>) map.get("presentations");
+        view
+            .html()
+                .head()
+                    .meta().attrCharset("utf-8").__()
+                    .meta().attrName("viewport").attrContent("width=device-width, initial-scale=1.0").__()
+                    .meta()
+                        .addAttr("http-equiv", "X-UA-Compatible")
+                        .attrContent("IE=Edge")
+                    .__()
+                    .title().text("JFall 2013 Presentations").__()
+                    .link()
+                        .attrRel(EnumRelType.STYLESHEET)
+                        .attrHref("/webjars/bootstrap/3.3.7-1/css/bootstrap.min.css")
+                        .attrMedia(EnumMediaType.SCREEN)
+                    .__()
+                .__()
+                .body()
+                    .div().attrClass("container")
+                        .div().attrClass("page-header")
+                            .h1().text("JFall 2013 Presentations").__()
+                        .__() // div
+                        .dynamic(container ->
+                            presentations.forEach(presentation ->
+                                container
+                                    .div().attrClass("panel panel-default")
+                                        .div().attrClass("panel-heading")
+                                            .h3()
+                                                .dynamic(h3 -> h3
+                                                    .attrClass("panel-title")
+                                                    .text(presentation.getTitle() + " - " + presentation.getSpeakerName())
+                                                )
+                                            .__()
+                                        .__()
+                                        .div()
+                                            .dynamic(d -> d
+                                                .attrClass("panel-body")
+                                                .text(presentation.getSummary())
+                                            )
+                                        .__() // div
+                                    .__() // div
+                            ) // foreach
+                        )
+                    .__() // container
+                .script().attrSrc("/webjars/jquery/3.1.1/jquery.min.js").__()
+                .script().attrSrc("/webjars/bootstrap/3.3.7-1/js/bootstrap.min.js").__()
+                .__() // body
+            .__(); // html
+    }
+}

--- a/src/main/java/com/jeroenreijn/examples/view/PresentationKotlin.kt
+++ b/src/main/java/com/jeroenreijn/examples/view/PresentationKotlin.kt
@@ -1,0 +1,55 @@
+package com.jeroenreijn.examples.view
+
+import com.jeroenreijn.examples.model.Presentation
+import kotlinx.html.*
+import kotlinx.html.dom.createHTMLDocument
+import kotlinx.html.dom.serialize
+
+class PresentationsKotlin {
+    companion object {
+
+        fun presentationsTemplate(presentations : Collection<Presentation> ): String {
+            return createHTMLDocument()
+                    .html {
+                        head {
+                            meta {charset = "utf-8" }
+                            meta {name = "viewport"; content = "width=device-width, initial-scale=1.0" }
+                            meta {httpEquiv=MetaHttpEquiv.contentLanguage; content="IE=Edge" }
+                            title { text("JFall 2013 Presentations - KotlinHtml")}
+                            link {rel=LinkRel.stylesheet; href="/webjars/bootstrap/3.3.7-1/css/bootstrap.min.css"; media = LinkMedia.screen}
+                        }
+                        body {
+                            div {
+                                classes = setOf("container")
+                                div {
+                                    classes = setOf("page-header")
+                                    h1 { text("JFall 2013 Presentations - htmlApi") }
+                                }
+
+                                presentations.forEach {
+                                    div {
+                                        classes = setOf("panel panel-default")
+                                        div {
+                                            classes = setOf("panel-heading")
+                                            h3 {
+                                                classes = setOf("panel-title")
+                                                text( it.title + " - " + it.speakerName)
+                                            }
+                                        }
+                                        div {
+                                            classes = setOf("panel-body")
+                                            text (it.summary)
+                                        }
+                                    }
+                                }
+                            }
+
+                            script { src = "/webjars/jquery/3.1.1/jquery.min.js" }
+                            script { src = "/webjars/bootstrap/3.3.7-1/js/bootstrap.min.js" }
+                        }
+                    }.serialize(false)
+        }
+    }
+
+
+}

--- a/src/main/resources/templates/presentations.rocker.raw
+++ b/src/main/resources/templates/presentations.rocker.raw
@@ -1,0 +1,40 @@
+@import com.jeroenreijn.examples.model.*
+@import java.lang.Iterable
+@args (Iterable<Presentation> items)
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta http-equiv="content-language" content="IE=Edge">
+		<title>
+			JFall 2013 Presentations - htmlApi
+		</title>
+		<link rel="Stylesheet" href="/webjars/bootstrap/3.3.7-1/css/bootstrap.min.css" media="screen">
+	</head>
+	<body>
+		<div class="container">
+			<div class="page-header">
+				<h1>
+					JFall 2013 Presentations - Rocker
+				</h1>
+			</div>
+			@for ((ForIterator i, Presentation item) : items) {
+				<div class="panel panel-default">
+					<div class="panel-heading">
+						<h3 class="panel-title">
+							@item.getTitle() - @item.getSpeakerName()
+						</h3>
+					</div>
+					<div class="panel-body">
+						@item.getSummary()
+					</div>
+				</div>
+			}
+		</div>
+		<script src="/webjars/jquery/3.1.1/jquery.min.js">
+		</script>
+		<script src="/webjars/bootstrap/3.3.7-1/js/bootstrap.min.js">
+		</script>
+	</body>
+</html>

--- a/src/main/webapp/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/src/main/webapp/WEB-INF/mvc-dispatcher-servlet.xml
@@ -198,6 +198,14 @@
     <property name="renderer" ref="jtwigRenderer"/>
   </bean>
 
+  <!-- HtmlApi -->
+    <bean id="htmlFlowViewResolver" class="com.jeroenreijn.examples.factory.HtmlFlowViewFactory">
+        <property name="viewNames" value="*-htmlFlow"/>
+        <property name="order" value="13"/>
+        <property name="exposeSpringMacroHelpers" value="true"/>
+        <property name="cache" value="true"/>
+    </bean>
+
   <!-- Handlebars -->
   <bean id="handlebarsViewResolver" class="com.github.jknack.handlebars.springmvc.HandlebarsViewResolver">
     <property name="viewNames" value="*-handlebars"/>

--- a/src/main/webapp/WEB-INF/mvc-dispatcher-servlet.xml
+++ b/src/main/webapp/WEB-INF/mvc-dispatcher-servlet.xml
@@ -198,10 +198,31 @@
     <property name="renderer" ref="jtwigRenderer"/>
   </bean>
 
-  <!-- HtmlApi -->
+  <!-- HtmlFlow -->
     <bean id="htmlFlowViewResolver" class="com.jeroenreijn.examples.factory.HtmlFlowViewFactory">
         <property name="viewNames" value="*-htmlFlow"/>
         <property name="order" value="13"/>
+        <property name="exposeSpringMacroHelpers" value="true"/>
+        <property name="cache" value="true"/>
+    </bean>
+
+    <bean id="rockerViewResolver" class="com.jeroenreijn.examples.factory.RockerViewFactory">
+        <property name="viewNames" value="*-rocker"/>
+        <property name="order" value="14"/>
+        <property name="exposeSpringMacroHelpers" value="true"/>
+        <property name="cache" value="true"/>
+    </bean>
+
+    <bean id="j2htmlViewResolver" class="com.jeroenreijn.examples.factory.J2HtmlViewFactory">
+        <property name="viewNames" value="*-j2html"/>
+        <property name="order" value="15"/>
+        <property name="exposeSpringMacroHelpers" value="true"/>
+        <property name="cache" value="true"/>
+    </bean>
+
+    <bean id="kotlinHtmlViewResolver" class="com.jeroenreijn.examples.factory.KotlinHtmlViewFactory">
+        <property name="viewNames" value="*-kotlinhtml"/>
+        <property name="order" value="16"/>
         <property name="exposeSpringMacroHelpers" value="true"/>
         <property name="cache" value="true"/>
     </bean>

--- a/src/test/java/com/jeroenreijn/examples/controller/MockHttpServletResponse.java
+++ b/src/test/java/com/jeroenreijn/examples/controller/MockHttpServletResponse.java
@@ -1,0 +1,199 @@
+package com.jeroenreijn.examples.controller;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.Locale;
+
+public class MockHttpServletResponse implements HttpServletResponse {
+
+    int contentLength;
+    String contentType;
+    final PrintWriter writer;
+
+    public MockHttpServletResponse(PrintWriter writer) {
+        this.writer = writer;
+    }
+
+    @Override
+    public void setContentLength(int contentLength) {
+        this.contentLength = contentLength;
+    }
+
+    @Override
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    @Override
+    public void addCookie(Cookie cookie) {
+    }
+
+    @Override
+    public boolean containsHeader(String s) {
+        return false;
+    }
+
+    @Override
+    public String encodeURL(String s) {
+        return null;
+    }
+
+    @Override
+    public String encodeRedirectURL(String s) {
+        return null;
+    }
+
+    @Override
+    public String encodeUrl(String s) {
+        return null;
+    }
+
+    @Override
+    public String encodeRedirectUrl(String s) {
+        return null;
+    }
+
+    @Override
+    public void sendError(int i, String s) throws IOException {
+
+    }
+
+    @Override
+    public void sendError(int i) throws IOException {
+
+    }
+
+    @Override
+    public void sendRedirect(String s) throws IOException {
+
+    }
+
+    @Override
+    public void setDateHeader(String s, long l) {
+
+    }
+
+    @Override
+    public void addDateHeader(String s, long l) {
+
+    }
+
+    @Override
+    public void setHeader(String s, String s1) {
+
+    }
+
+    @Override
+    public void addHeader(String s, String s1) {
+
+    }
+
+    @Override
+    public void setIntHeader(String s, int i) {
+
+    }
+
+    @Override
+    public void addIntHeader(String s, int i) {
+
+    }
+
+    @Override
+    public void setStatus(int i) {
+
+    }
+
+    @Override
+    public void setStatus(int i, String s) {
+
+    }
+
+    @Override
+    public int getStatus() {
+        return 0;
+    }
+
+    @Override
+    public String getHeader(String s) {
+        return null;
+    }
+
+    @Override
+    public Collection<String> getHeaders(String s) {
+        return null;
+    }
+
+    @Override
+    public Collection<String> getHeaderNames() {
+        return null;
+    }
+
+    @Override
+    public String getCharacterEncoding() {
+        return null;
+    }
+
+    @Override
+    public String getContentType() {
+        return null;
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream() throws IOException {
+        return null;
+    }
+
+    @Override
+    public PrintWriter getWriter() throws IOException {
+        return writer;
+    }
+
+    @Override
+    public void setCharacterEncoding(String s) {
+
+    }
+
+    @Override
+    public void setBufferSize(int i) {
+
+    }
+
+    @Override
+    public int getBufferSize() {
+        return 0;
+    }
+
+    @Override
+    public void flushBuffer() throws IOException {
+
+    }
+
+    @Override
+    public void resetBuffer() {
+
+    }
+
+    @Override
+    public boolean isCommitted() {
+        return false;
+    }
+
+    @Override
+    public void reset() {
+
+    }
+
+    @Override
+    public void setLocale(Locale locale) {
+
+    }
+
+    @Override
+    public Locale getLocale() {
+        return null;
+    }
+}

--- a/src/test/java/com/jeroenreijn/examples/controller/PresentationsViewTest.java
+++ b/src/test/java/com/jeroenreijn/examples/controller/PresentationsViewTest.java
@@ -1,0 +1,98 @@
+package com.jeroenreijn.examples.controller;
+
+import com.jeroenreijn.examples.factory.HtmlFlowViewFactory;
+import com.jeroenreijn.examples.InMemoryPresentationsRepository;
+import com.jeroenreijn.examples.PresentationsRepository;
+import com.jeroenreijn.examples.model.Presentation;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.web.context.support.GenericWebApplicationContext;
+import org.springframework.web.servlet.support.RequestContext;
+import org.springframework.web.servlet.view.AbstractTemplateView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static junit.framework.Assert.assertEquals;
+
+public class PresentationsViewTest {
+
+    private final Map<String, Object> model;
+    private static final Pattern GREATER = Pattern.compile(">");
+
+    public PresentationsViewTest() {
+        PresentationsRepository repo = new InMemoryPresentationsRepository();
+        Iterable<Presentation> presentations = repo.findAll();
+        model = new HashMap<>();
+        model.put("presentations", presentations);
+    }
+
+    @Test
+    public void htmlFlow_presentations_test() throws Exception {
+        AbstractTemplateView view = getViewFromResolver(HtmlFlowViewFactory.class);
+        ByteArrayOutputStream mem = new ByteArrayOutputStream();
+        view.render(model, request(view), response(mem));
+        /*
+         * Assert
+         */
+        String html = mem.toString().replaceAll("\\s", "").toLowerCase();
+        Iterator<String> actual = GREATER.splitAsStream(html).iterator();
+        GREATER
+            .splitAsStream(readExpectedOutputResource())
+            .forEach(expected -> assertEquals(expected, actual.next()));
+    }
+
+    private static AbstractTemplateView getViewFromResolver(Class resolver)
+        throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException
+    {
+        Object hfResolver = resolver.getConstructor().newInstance();
+        Method requiredViewClass = HtmlFlowViewFactory.class.getDeclaredMethod("requiredViewClass");
+        requiredViewClass.setAccessible(true);
+        Class<?> viewClass = (Class<?>) requiredViewClass.invoke(hfResolver);
+        return (AbstractTemplateView) viewClass.getConstructor().newInstance();
+    }
+
+    private static HttpServletResponse response(ByteArrayOutputStream mem) {
+        PrintWriter writer = new PrintWriter(new OutputStreamWriter(mem));
+        MockHttpServletResponse resp = new MockHttpServletResponse(writer);
+        return resp;
+    }
+
+    private static HttpServletRequest request(AbstractTemplateView view) {
+        MockServletContext ctx = new MockServletContext();
+        ctx.setContextPath("HtmlFlow");
+        final MockHttpServletRequest req = new MockHttpServletRequest(ctx);
+
+        GenericWebApplicationContext appCtx = new GenericWebApplicationContext(req.getServletContext());
+        view.setApplicationContext(appCtx);
+        req.setAttribute(RequestContext.WEB_APPLICATION_CONTEXT_ATTRIBUTE, appCtx);
+        return req;
+    }
+
+    private String readExpectedOutputResource() throws IOException {
+        try(BufferedReader in = new BufferedReader(
+                new InputStreamReader(
+                    PresentationsViewTest.class.getResourceAsStream("/ExpectedPresentations.html"))))
+        {
+            return in
+                .lines()
+                .collect(Collectors.joining())
+                .replaceAll("\\s", "")
+                .toLowerCase();
+        }
+    }
+}

--- a/src/test/resources/ExpectedPresentations.html
+++ b/src/test/resources/ExpectedPresentations.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+  <title>
+    JFall 2013 Presentations
+  </title>
+  <link rel="stylesheet" href="/webjars/bootstrap/3.3.7-1/css/bootstrap.min.css" media="screen">
+</head>
+<body>
+<div class="container">
+  <div class="page-header">
+    <h1>
+        JFall 2013 Presentations
+    </h1>
+  </div>
+  <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">
+            Shootout! Template engines on the JVM - Jeroen Reijn
+        </h3>
+      </div>
+      <div class="panel-body">
+          Are you still using JavaServer Pages as your main template language? With the popularity of template engines for other languages like Ruby and Scala and the shift in doing more MVC in the browser there are quite some new and interesting new template languages available for the JVM. During this session we will take a look at the less known, but quite interesting new template engines and see how they compare with the industries standards.<br/>
+      </div>
+    </div>
+  <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">
+            HoneySpider Network: a Java based system to hunt down malicious websites - Niels van Eijck
+        </h3>
+      </div>
+      <div class="panel-body">
+          Legitimate websites such as news sites happen to get compromised by attackers injecting malicious content. The aim of these so-called &#8220;watering hole attacks&#8221; is to infect as many visitors of a website as possible, and are sometimes even targeted at a specific group of individuals. It is increasingly important to detect these infections at an early stage.
+          <br/>
+          <br/>
+          HoneySpider Network to the rescue!
+          <br/>
+          <br/>It is a Java based open source framework that automatically scans website urls, analyses the results and reports on any malware detected.
+          <br/>Attend this talk to gain a better understanding of malware detection and client honeypots and get an overview of the HoneySpider Network&#8217;s architecture, its code and its plugins it uses. A live demo is also included!</div>
+      </div>
+  <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Building scalable network applications with Netty - Jaap ter Woerds</h3>
+      </div>
+      <div class="panel-body">
+          Since the introduction of the Java NIO API&apos;s with Java 4, developers have
+<br/>access to modern operating system facilities to perform asynchronous IO.
+<br/>Using these facilities it is possible to write networking application that that
+<br/>serve thousands of connected clients efficiently. Unfortunately, the NIO API&apos;s
+<br/>are quite low level and require a fair share of boilerplate to get started.
+<br/>In this presentation, I will introduce the Netty framework and how its
+<br/>architecture helps you as a developer stay focused on the interesting parts
+<br/>of your network application. At the end of the presentation I will give some
+<br/>real world examples and show how we use Netty in the architecture of our
+<br/>mobile messaging platform XMS.</div>
+    </div>
+  <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Opening - Bert Ertman</h3>
+      </div>
+      <div class="panel-body">
+          De openingssessie van de conferentie met aandacht voor de dag zelf en nieuws vanuit de NLJUG. De sessie wordt gepresenteerd door Bert Ertman.</div>
+    </div>
+  <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Keynote door ING - Amir Arroni</h3>
+      </div>
+      <div class="panel-body">
+          Keynote van ING, gepresenteerd door Amir Arooni en Peter Jacobs.</div>
+    </div>
+  <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Keynote door Oracle - Sharat Chander</h3>
+      </div>
+      <div class="panel-body">
+          Keynote van Oracle, gepresenteerd door Sharat Chander.</div>
+    </div>
+  <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Reactieve applicaties ? klaar voor te toekomst - Allard Buijze</h3>
+      </div>
+      <div class="panel-body">
+          De technische eisen aan webapplicaties veranderen in hoog tempo. Enkele jaren geleden nog gebruikten de grootere applicaties enkele tientallen servers en werden response tijden van een seconde en onderhoudsvensters van enkele uren nog geaccepteerd. Tegenwoordig moeten applicaties 100% beschikbaar zijn, terwijl de gebruiker in enkele milliseconden antwoord wil krijgen. Om pieken in gebruik op te kunnen vangen moeten de applicaties op duizenden processoren in een cloud omgeving kunnen draaien.
+<br/>De tekortkomingen van de huidige standaard architectuurprincipes kunnen worden opgevangen door een zogenaamde &#8220;reactive architecture&#8221;. Reactieve applicaties bezitten een aantal eigenschappen waardoor ze beter kunnen omgaan met opschalen, bestand zijn tegen fouten en bovendien efficienter gebruik maken van beschikbare server-bronnen.
+<br/>In deze presentatie laat Allard zien hoe deze eigenschappen gerealiseerd kunnen worden en welke reeds bekende architectuurpatronen en frameworks hieraan een bijdrage leveren.</div>
+    </div>
+  <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">HTML 5 Geolocation + WebSockets + Scalable JavaEE Backend === Awesome Realtime Location Aware Applications - Shekhar Gulati</h3>
+      </div>
+      <div class="panel-body">
+          Location Aware apps are everywhere and we use them heavily in our day to day life. You have seen the stuff that Foursquare has done with spatial and you want some of that hotness for your app. But, where to start? In this session, we will build a location aware app using HTML 5 on the client and scalable JavaEE + MongoDB on the server side. HTML 5 GeoLocation API help us to find user current location and MongoDB offers Geospatial indexing support which provides an easy way to get started and enables a variety of location-based applications - ranging from field resource management to social check-ins. Next we will add realtime capabilities to our application using Pusher. Pusher provides scalable WebSockets as a service. The Java EE 6 backend will be built using couple of Java EE 6 technologies -- JAXRS and CDI. Finally , we will deploy our Java EE application on OpenShift -- Red Hat&apos;s public, scalable Platform as a Service.</div>
+    </div>
+  <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Retro Gaming with Lambdas - Stephen Chin</h3>
+      </div>
+      <div class="panel-body">
+          Lambda expressions are coming in Java 8 and dramatically change the programming model.  They allow new functional programming patterns that were not possible before, increasing the expressiveness and power of the Java language.
+<br/>
+<br/>In this university session, you will learn how to take advantage of the new lambda-enabled Java 8 APIs by building out a retro video game in JavaFX.
+<br/>
+<br/>Some of the Java 8 features you will learn about include enhanced collections, functional interfaces, simplified event handlers, and the new stream API.  Start using these in your application today leveraging the latest OpenJDK builds so you can prepare for the future Java 8 release.</div>
+    </div>
+  <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Data Science with R for Java Developers - Sander Mak</h3>
+      </div>
+      <div class="panel-body">
+          Understanding data is increasingly important to create cutting-edge applications. A whole new data science field is emerging, with the open source R language as a leading technology. This statistical programming language is specifically designed for analyzing and understanding data.
+<br/>
+<br/>In this session we approach R from the perspective of Java developers. How do you get up to speed quickly, what are the pitfalls to look out for?  Also we discuss how to bridge the divide between the R language and the JVM. After this session you can use your new skills to explore an exciting world of data analytics and machine learning! </div>
+    </div>
+  </div>
+<script src="/webjars/jquery/3.1.1/jquery.min.js"></script>
+<script src="/webjars/bootstrap/3.3.7-1/js/bootstrap.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
[HtmlFlow](https://github.com/xmlet/HtmlFlow)  is a Java DSL to write typesafe HTML documents.  

Issue #34

HtmlFlow is at least two fold faster than the current best template engine in spring-comparing-template-engines.

HtmlFlow is widely used to build dynamic HTML documents, such as papers, reports, emails, etc, involving complex programing tasks which are hardly achieved through textual templates. Moreover, HtmlFlow can also be used as a web template engine allying its performance boost with its HTML strongly type safety characteristics.
