### PR TITLE
Upgrade HtmlFlow to release 3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		<pebble.version>3.0.7</pebble.version>
 		<scala.version>2.11</scala.version>
 		<scalate-core.version>1.9.3</scalate-core.version>
-		<htmlflow.version>3.2</htmlflow.version>
+		<htmlflow.version>3.5</htmlflow.version>
 		<trimou.version>2.5.0.Final</trimou.version>
 		<rocker.version>1.2.1</rocker.version>
 		<ickenham-springmvc.version>1.4.1</ickenham-springmvc.version>

--- a/src/main/java/com/jeroenreijn/examples/view/HtmlFlowIndexView.java
+++ b/src/main/java/com/jeroenreijn/examples/view/HtmlFlowIndexView.java
@@ -11,9 +11,9 @@ import htmlflow.DynamicHtml;
 import htmlflow.HtmlView;
 
 public class HtmlFlowIndexView {
-	public static HtmlView<Map<String, Object>> getView() {
-		return DynamicHtml.view(HtmlFlowIndexView::templatePresentations);
-	}
+	public static final HtmlView<Map<String, Object>> view = DynamicHtml
+		.view(HtmlFlowIndexView::templatePresentations)
+		.threadSafe();
 
 	private static void templatePresentations(DynamicHtml<Map<String, Object>> view, Map<String, Object> map) {
 		@SuppressWarnings("unchecked")
@@ -46,14 +46,14 @@ public class HtmlFlowIndexView {
 									.div().attrClass("card mb-3 shadow-sm rounded")
 										.div().attrClass("card-header")
 											.h5()
-												.dynamic(h5 -> h5
+												.of(h5 -> h5
 													.attrClass("card-title")
 													.text(presentation.getTitle() + " - " + presentation.getSpeakerName())
 												)
 											.__() // h5
 										.__() // div
 										.div()
-											.dynamic(d -> d
+											.of(d -> d
 												.attrClass("card-body")
 												.text(presentation.getSummary())
 											)

--- a/src/main/java/com/jeroenreijn/examples/view/HtmlFlowView.java
+++ b/src/main/java/com/jeroenreijn/examples/view/HtmlFlowView.java
@@ -13,7 +13,7 @@ public class HtmlFlowView extends AbstractTemplateView {
 	@Override
 	protected void renderMergedTemplateModel(Map<String, Object> model, HttpServletRequest request,
 			HttpServletResponse response) throws Exception {
-		String html = HtmlFlowIndexView.getView().render(model);
+		String html = HtmlFlowIndexView.view.render(model);
 
 		response.setContentLength(html.length());
 		response.setContentType("text/html");


### PR DESCRIPTION
* Fixed a problem where the block html was written two times into the response. Reported by @Vest at https://github.com/jreijn/spring-comparing-template-engines/issues/34#issuecomment-490099263
* Updated the `HtmlFlowIndexView` according to the new behavior of HtmlFlow in version 3.3. (https://github.com/xmlet/HtmlFlow#33-august-2019) where it: ”_disallows the use of chained calls to `dynamic()` due to unexpected cache behaviors._”. Thus we had to replace the inner invocations of `dynamic()` by `of()`.
* Changed the static method `getView()` of `HtmlFlowIndexView` with a static field `view`.
* Added the `threadSafe()` initialization to the previous view to enable safe use on concurrent benchmarks.