### PR TITLE
Jmh benchmark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.jeroenreijn</groupId>
     <artifactId>spring-comparing-template-engines</artifactId>
-    <packaging>war</packaging>
+    <packaging>jar</packaging>
     <version>0.8.0-SNAPSHOT</version>
     <name>template-engines</name>
 
@@ -40,6 +40,7 @@
         <liqp.version>0.7.9</liqp.version>
         <kotlin.version>1.7.20</kotlin.version>
         <kotlinx.html.version>0.8.0</kotlinx.html.version>
+        <jmh.version>1.35</jmh.version>
     </properties>
 
     <parent>
@@ -269,8 +270,23 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
+            <!--Benchmarking should not be on test, however a mock is required for benchmarking -->
+			<!--spring-boot-starter-test only for benchmarking!-->
+            <!-- <scope>test</scope> -->
         </dependency>
+
+        <!-- Benchmark -->
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<version>${jmh.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
+			<version>${jmh.version}</version>
+			<scope>provided</scope>
+		</dependency>
 
     </dependencies>
 
@@ -324,7 +340,6 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
-
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
@@ -355,6 +370,43 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.4.1</version>
+				<executions>
+					<execution>
+                        <id>shade-my-jar</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+							</transformers>
+							<filters>
+								<filter>
+									<!--
+                                        Shading signed JARs will fail without this.
+                                        http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                                    -->
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
+									</excludes>
+								</filter>
+							</filters>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
         </plugins>
 
         <pluginManagement>

--- a/src/main/java/com/jeroenreijn/examples/LaunchJMH.java
+++ b/src/main/java/com/jeroenreijn/examples/LaunchJMH.java
@@ -1,0 +1,154 @@
+package com.jeroenreijn.examples;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.String.format;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+/**
+ * Some code on this class has been sampled from https://stackoverflow.com/a/41499972
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+public class LaunchJMH {
+
+    static ConfigurableApplicationContext context;
+    static MockMvc mockMvc;
+
+    @Setup(Level.Trial)
+    public synchronized void startupSpring() {
+        try {
+            if (context == null) {
+                context = SpringApplication.run(Launch.class);
+                mockMvc = MockMvcBuilders
+                        .webAppContextSetup((WebApplicationContext) context)
+                        .build();
+            }
+        } catch (Exception e) {
+            //Force JMH crash
+            throw new RuntimeException(e);
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public synchronized void shutdownSpring() {
+        try {
+            if (context != null) {
+                SpringApplication.exit(context);
+                context = null;
+            }
+        } catch (Exception e) {
+            //Force JMH crash
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String benchmarkTemplate(String template) {
+        try {
+            ResultActions res = mockMvc.perform(
+                get(format("/%s", template))
+                    .accept(MediaType.ALL_VALUE)
+            );
+            return res.andReturn().getResponse().getContentAsString();
+        } catch (Exception e) {
+            //Force JMH crash
+            throw new RuntimeException(e);
+        }
+    }
+    @Benchmark
+    public String benchmarkChunk() {
+        return benchmarkTemplate("chunk");
+    }
+    @Benchmark
+    public String benchmarkFreemarker() {
+        return benchmarkTemplate("freemarker");
+    }
+    @Benchmark
+    public String benchmarkGroovy() {
+        return benchmarkTemplate("groovy");
+    }
+    @Benchmark
+    public String benchmarkHandlebars() {
+        return benchmarkTemplate("handlebars");
+    }
+    @Benchmark
+    public String benchmarkHtmlFlow() {
+        return benchmarkTemplate("htmlFlow");
+    }
+    @Benchmark
+    public String benchmarkHttl() {
+        return benchmarkTemplate("httl");
+    }
+        @Benchmark
+    public String benchmarkIckenham() {
+        return benchmarkTemplate("ickenham");
+    }
+    @Benchmark
+    public String benchmarkJade() {
+        return benchmarkTemplate("jade");
+    }
+    // Biased results because JSP resolver is not being invoked with MockMVC
+    // and it is always resolved with an empty view!!!!
+    @Benchmark
+    public String benchmarkJsp() {
+        return benchmarkTemplate("jsp");
+    }
+    @Benchmark
+    public String benchmarkKotlinxHtml() {
+        return benchmarkTemplate("kotlinx");
+    }
+    @Benchmark
+    public String benchmarkLiqp() {
+        return benchmarkTemplate("liqp");
+    }
+    @Benchmark
+    public String benchmarkMustache() {
+        return benchmarkTemplate("mustache");
+    }
+    @Benchmark
+    public String benchmarkPebble() {
+        return benchmarkTemplate("pebble");
+    }
+    @Benchmark
+    public String benchmarkRocker() {
+        return benchmarkTemplate("rocker");
+    }
+    @Benchmark
+    public String benchmarkRythm() {
+        return benchmarkTemplate("rythm");
+    }
+    @Benchmark
+    public String benchmarkScalate() {
+        return benchmarkTemplate("scalate");
+    }
+    @Benchmark
+    public String benchmarkThymeleaf() {
+        return benchmarkTemplate("thymeleaf");
+    }
+    @Benchmark
+    public String benchmarkTrimou() {
+        return benchmarkTemplate("trimou");
+    }
+    @Benchmark
+    public String benchmarkVelocity() {
+        return benchmarkTemplate("velocity");
+    }
+}

--- a/src/main/java/com/jeroenreijn/examples/configuration/WebMvcConfig.java
+++ b/src/main/java/com/jeroenreijn/examples/configuration/WebMvcConfig.java
@@ -45,7 +45,7 @@ import java.util.Map;
 
 @Configuration
 @EnableWebMvc
-@ComponentScan(basePackages = { "com.jeroenreijn.examples.controller", "com.jeroenreijn.examples.factory" })
+@ComponentScan(basePackages = { "com.jeroenreijn.examples.controller", "com.jeroenreijn.examples" })
 public class WebMvcConfig implements ApplicationContextAware, WebMvcConfigurer {
 	private ApplicationContext applicationContext;
 

--- a/src/main/java/com/jeroenreijn/examples/view/KotlinxHtmlIndexView.kt
+++ b/src/main/java/com/jeroenreijn/examples/view/KotlinxHtmlIndexView.kt
@@ -10,13 +10,14 @@ class KotlinxHtmlIndexView {
         fun presentationsTemplate(presentations : Iterable<Presentation> ): String {
             val output = StringBuilder()
             output
+                .appendLine("<!DOCTYPE html>")
                 .appendHTML()
                     .html {
                         head {
                             meta {charset = "utf-8" }
                             meta {name = "viewport"; content = "width=device-width, initial-scale=1.0" }
-                            meta {httpEquiv=MetaHttpEquiv.contentLanguage; content="IE=Edge" }
-                            title { text("JFall 2013 Presentations - htmlApi")}
+                            meta {httpEquiv="x-ua-compatible"; content="IE=Edge" }
+                            title { text("JFall 2013 Presentations - kotlinx.html")}
                             link {rel=LinkRel.stylesheet; href="/webjars/bootstrap/4.3.1/css/bootstrap.min.css"; media = LinkMedia.screen;}
                         }
                         body {
@@ -32,7 +33,7 @@ class KotlinxHtmlIndexView {
                                         classes = setOf("card mb-3 shadow-sm rounded")
                                         div {
                                             classes = setOf("card-header")
-                                            h3 {
+                                            h5 {
                                                 classes = setOf("card-title")
                                                 text( it.title + " - " + it.speakerName)
                                             }

--- a/src/main/resources/templates/freemarker/includes.ftl
+++ b/src/main/resources/templates/freemarker/includes.ftl
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
   <title>[@spring.message code="example.title"/] - Freemarker</title>
-  <link rel="stylesheet" href="${springMacroRequestContext.getContextPath()}/webjars/bootstrap/4.3.1/css/bootstrap.min.css" media="screen" />
+  <link rel="stylesheet" href="${springMacroRequestContext.getContextPath()}/webjars/bootstrap/4.3.1/css/bootstrap.min.css" media="screen"/>
 </head>
 [/#macro]
 

--- a/src/main/resources/templates/groovy/base.tpl
+++ b/src/main/resources/templates/groovy/base.tpl
@@ -1,5 +1,5 @@
 yieldUnescaped '<!DOCTYPE html>'
-html(lang:'en') {
+html {
   head {
     include template: 'head.tpl'
   }
@@ -11,7 +11,6 @@ html(lang:'en') {
 
 	  mainBody()
     }
+    include template: 'scripts.tpl'
   }
-
-  include template: 'scripts.tpl'
 }

--- a/src/main/resources/templates/groovy/head.tpl
+++ b/src/main/resources/templates/groovy/head.tpl
@@ -1,4 +1,4 @@
-meta(charset: 'UTF8')
+meta(charset: 'UTF-8')
 meta(name: 'viewport', content: 'width=device-width, initial-scale=1.0')
 meta('http-equiv': 'X-UA-Compatible', 'content': 'IE=Edge')
 title(title)

--- a/src/main/resources/templates/httl/index-httl.httl
+++ b/src/main/resources/templates/httl/index-httl.httl
@@ -24,7 +24,7 @@
     </div>
     <!--#end-->
 </div>
-<script src=${contextPath}/webjars/jquery/3.1.1/jquery.min.js></script>
-<script src=${contextPath}/webjars/bootstrap/4.3.1/js/bootstrap.min.js></script>
+<script src="${contextPath}/webjars/jquery/3.1.1/jquery.min.js"></script>
+<script src="${contextPath}/webjars/bootstrap/4.3.1/js/bootstrap.min.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/trimou/head.trimou
+++ b/src/main/resources/templates/trimou/head.trimou
@@ -3,5 +3,5 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
     <title>{{springMsg "example.title" "Unknown i18n"}} - Trimou</title>
-    <link rel="stylesheet" href="/webjars/bootstrap/4.3.1/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="/webjars/bootstrap/4.3.1/css/bootstrap.min.css" media="screen"/>
 </head>

--- a/src/main/resources/templates/velocity/includes.vm
+++ b/src/main/resources/templates/velocity/includes.vm
@@ -4,7 +4,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
     <title>#springMessage("example.title") - Velocity</title>
-    <link rel="stylesheet" href="$link.relative("/webjars/bootstrap/4.3.1/css/bootstrap.min.css")" media="screen" />
+    <link rel="stylesheet" href="$link.relative("/webjars/bootstrap/4.3.1/css/bootstrap.min.css")" media="screen"/>
 </head>
 #end
 

--- a/src/main/resources/templates/velocity/index-velocity.vm
+++ b/src/main/resources/templates/velocity/index-velocity.vm
@@ -14,7 +14,7 @@
           </div>
       </div>
   #end
-  #scripts()
 </div>
+#scripts()
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/handlebars/head.hbs
+++ b/src/main/webapp/WEB-INF/handlebars/head.hbs
@@ -3,5 +3,5 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
     <title>{{i18n "example.title"}} - Handlebars</title>
-    <link rel="stylesheet" href="{{springMacroRequestContext.contextPath}}/webjars/bootstrap/4.3.1/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="{{springMacroRequestContext.contextPath}}/webjars/bootstrap/4.3.1/css/bootstrap.min.css" media="screen"/>
 </head>

--- a/src/main/webapp/WEB-INF/handlebars/presentation.hbs
+++ b/src/main/webapp/WEB-INF/handlebars/presentation.hbs
@@ -1,6 +1,6 @@
 <div class="card mb-3 shadow-sm rounded">
     <div class="card-header">
-        <h5 class="card-title">{{title}} - {{speakerName}}</h5>
+        <h5 class="card-title">{{{title}}} - {{speakerName}}</h5>
     </div>
     <div class="card-body">
         {{{summary}}}

--- a/src/main/webapp/WEB-INF/ickenham/head.hbs
+++ b/src/main/webapp/WEB-INF/ickenham/head.hbs
@@ -3,5 +3,5 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
     <title>{{i18n "example.title"}} - Ickenham</title>
-    <link rel="stylesheet" href="{{rc.contextPath}}/webjars/bootstrap/4.3.1/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="{{rc.contextPath}}/webjars/bootstrap/4.3.1/css/bootstrap.min.css" media="screen"/>
 </head>

--- a/src/main/webapp/WEB-INF/jade/layout.jade
+++ b/src/main/webapp/WEB-INF/jade/layout.jade
@@ -1,10 +1,11 @@
 doctype html
 html
   head
-    meta(name="charset", content="UTF-8")
-    title #{i18n.message("example.title")} - Jade4j
-    link(rel="stylesheet", href=springMacroRequestContext.contextPath + "/webjars/bootstrap/4.3.1/css/bootstrap.min.css")
+    meta(charset="UTF-8")
     meta(name="viewport", content="width=device-width, initial-scale=1.0")
+    meta(http-equiv="X-UA-Compatible", content="IE=Edge")
+    title #{i18n.message("example.title")} - Jade4j
+    link(rel="stylesheet", href=springMacroRequestContext.contextPath + "/webjars/bootstrap/4.3.1/css/bootstrap.min.css", media="screen")
   body
     .container
         .pb-2.mt-4.mb-3.border-bottom

--- a/src/main/webapp/WEB-INF/mustache/head.mustache
+++ b/src/main/webapp/WEB-INF/mustache/head.mustache
@@ -3,5 +3,5 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
     <title>{{#i18n}}example.title{{/i18n}} - Mustache</title>
-    <link rel="stylesheet" href="{{rc.contextPath}}/webjars/bootstrap/4.3.1/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="{{rc.contextPath}}/webjars/bootstrap/4.3.1/css/bootstrap.min.css" media="screen"/>
 </head>

--- a/src/main/webapp/WEB-INF/mustache/presentation.mustache
+++ b/src/main/webapp/WEB-INF/mustache/presentation.mustache
@@ -1,6 +1,6 @@
 <div class="card mb-3 shadow-sm rounded">
     <div class="card-header">
-        <h5 class="card-title">{{title}} - {{speakerName}}</h5>
+        <h5 class="card-title">{{{title}}} - {{speakerName}}</h5>
     </div>
     <div class="card-body">
         {{{summary}}}

--- a/src/main/webapp/WEB-INF/thymeleaf/includes.html
+++ b/src/main/webapp/WEB-INF/thymeleaf/includes.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
     <title th:text="#{example.title} + ' - Thymeleaf'">Title</title>
-    <link rel="stylesheet" th:href="@{/webjars/bootstrap/4.3.1/css/bootstrap.min.css}"/>
+    <link rel="stylesheet" th:href="@{/webjars/bootstrap/4.3.1/css/bootstrap.min.css}" media="screen"/>
 </head>
 
 <body>

--- a/src/test/java/com/jeroenreijn/examples/JmhTest.java
+++ b/src/test/java/com/jeroenreijn/examples/JmhTest.java
@@ -1,0 +1,152 @@
+package com.jeroenreijn.examples;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Iterator;
+import java.util.regex.Pattern;
+
+import static java.util.stream.Collectors.joining;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class JmhTest {
+
+    final LaunchJMH jmh = new LaunchJMH();
+
+    public JmhTest() {
+        jmh.startupSpring();
+    }
+    static final InputStream stream = JmhTest.class.getClassLoader().getResourceAsStream("expected-output.html");
+	static final String expectedBody = new BufferedReader(new InputStreamReader(stream)).lines().collect(joining(""));
+    static final Pattern MARKUP = Pattern.compile("<");
+    static final Pattern NEWLINE = Pattern.compile("\n");
+
+    private static void assertTemplateOutput(String actual, String name) {
+		Iterator<String> expected = MARKUP
+			.splitAsStream(expectedBody.replace("JSP", name))
+			.iterator();
+		MARKUP
+			.splitAsStream(removeNewlinesTrimAndJoint(actual))
+			.forEach(act -> {
+				String e = expected.next().trim().toLowerCase();
+				String a = act
+				    .trim()
+				    .toLowerCase()
+                    .replaceAll("/>", ">")  // Some views still use void elements with a trailing / (slash).
+				    .replaceAll("'", "\""); // Some views use ' instead of "
+				assertEquals(e, a);
+			});
+		assertFalse(expected.hasNext());
+	}
+    private static String removeNewlinesTrimAndJoint(String source) {
+        return NEWLINE
+			.splitAsStream(source)
+			.map(String::trim)
+			.collect(joining(""));
+    }
+
+    @Test
+	public void should_return_view_content_for_Chunk() throws Exception {
+        String html = jmh.benchmarkChunk();
+        assertTemplateOutput(html, "chunk");
+    }
+    @Test
+	public void should_return_view_content_for_Freemarker() throws Exception {
+        String html = jmh.benchmarkFreemarker();
+        assertTemplateOutput(html, "freemarker");
+    }
+    @Test
+	public void should_return_view_content_for_Groovy() throws Exception {
+        String html = jmh.benchmarkGroovy();
+        assertTemplateOutput(html, "groovy");
+    }
+    @Test
+	public void should_return_view_content_for_Handlebars() throws Exception {
+        String html = jmh.benchmarkHandlebars();
+        assertTemplateOutput(html, "handlebars");
+    }
+    @Test
+	public void should_return_view_content_for_HtmlFlow() throws Exception {
+        String html = jmh.benchmarkHtmlFlow();
+        assertTemplateOutput(html, "htmlFlow");
+    }
+    @Test
+	public void should_return_view_content_for_HtmlHttl() throws Exception {
+        String html = jmh.benchmarkHttl();
+        assertTemplateOutput(html, "httl");
+    }
+    @Test
+	public void should_return_view_content_for_Ickeman() throws Exception {
+        String html = jmh.benchmarkIckenham();
+        assertTemplateOutput(html, "ickenham");
+    }
+    @Test
+	public void should_return_view_content_for_Jade() throws Exception {
+        String html = jmh.benchmarkJade();
+        assertTemplateOutput(html, "jade4j");
+    }
+    @Test
+	public void should_return_view_content_for_JSP() throws Exception {
+        String html = jmh.benchmarkJsp();
+        System.out.println(html);
+    }
+    @Test
+	public void should_return_view_content_for_KotlinxHtml() throws Exception {
+        String html = jmh.benchmarkKotlinxHtml();
+        assertTemplateOutput(html, "kotlinx.html");
+    }
+    @Test
+	public void should_return_view_content_for_Liqp() throws Exception {
+        String html = jmh.benchmarkLiqp();
+        assertTemplateOutput(html, "liqp");
+    }
+    @Test
+	public void should_return_view_content_for_Mustache() throws Exception {
+        String html = jmh.benchmarkMustache();
+        assertTemplateOutput(html, "mustache");
+    }
+    @Test
+	public void should_return_view_content_for_Pebble() throws Exception {
+        String html = jmh.benchmarkPebble();
+        assertTemplateOutput(html, "pebble");
+    }
+    @Test
+	public void should_return_view_content_for_Rocker() throws Exception {
+        String html = jmh.benchmarkRocker();
+        assertTemplateOutput(html, "rocker");
+    }
+    @Test
+	public void should_return_view_content_for_Rythm() throws Exception {
+        String html = jmh.benchmarkRythm();
+        assertTemplateOutput(html, "rythm");
+    }
+    @Test
+	public void should_return_view_content_for_Scalate() throws Exception {
+        String html = jmh.benchmarkScalate();
+        assertTemplateOutput(html, "scalate");
+    }
+    @Test
+	public void should_return_view_content_for_Thymeleaf() throws Exception {
+        String html = jmh.benchmarkThymeleaf();
+        assertTemplateOutput(html, "thymeleaf");
+    }
+    @Test
+	public void should_return_view_content_for_Trimou() throws Exception {
+        String html = jmh.benchmarkTrimou();
+        assertTemplateOutput(html, "trimou");
+    }
+    @Test
+	public void should_return_view_content_for_Velocity() throws Exception {
+        String html = jmh.benchmarkVelocity();
+        assertTemplateOutput(html, "velocity");
+    }
+
+}

--- a/src/test/resources/expected-output.html
+++ b/src/test/resources/expected-output.html
@@ -1,0 +1,83 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+    <title>JFall 2013 Presentations - JSP</title>
+    <link rel="stylesheet" href="/webjars/bootstrap/4.3.1/css/bootstrap.min.css" media="screen">
+</head>
+<body>
+	<div class="container">
+        <div class="pb-2 mt-4 mb-3 border-bottom">
+    <h1>JFall 2013 Presentations - JSP</h1>
+</div>
+        <div class="card mb-3 shadow-sm rounded">
+            <div class="card-header">
+                <h5 class="card-title">Shootout! Template engines on the JVM - Jeroen Reijn</h5>
+            </div>
+            <div class="card-body">Are you still using JavaServer Pages as your main template language? With the popularity of template engines for other languages like Ruby and Scala and the shift in doing more MVC in the browser there are quite some new and interesting new template languages available for the JVM. During this session we will take a look at the less known, but quite interesting new template engines and see how they compare with the industries standards.</div>
+        </div>
+        <div class="card mb-3 shadow-sm rounded">
+            <div class="card-header">
+                <h5 class="card-title">HoneySpider Network: a Java based system to hunt down malicious websites - Niels van Eijck</h5>
+            </div>
+            <div class="card-body">Legitimate websites such as news sites happen to get compromised by attackers injecting malicious content. The aim of these so-called &#8220;watering hole attacks&#8221; is to infect as many visitors of a website as possible, and are sometimes even targeted at a specific group of individuals. It is increasingly important to detect these infections at an early stage.<br><br>HoneySpider Network to the rescue!<br><br>It is a Java based open source framework that automatically scans website urls, analyses the results and reports on any malware detected.<br>Attend this talk to gain a better understanding of malware detection and client honeypots and get an overview of the HoneySpider Network&#8217;s architecture, its code and its plugins it uses. A live demo is also included!</div>
+        </div>
+        <div class="card mb-3 shadow-sm rounded">
+            <div class="card-header">
+                <h5 class="card-title">Building scalable network applications with Netty - Jaap ter Woerds</h5>
+            </div>
+            <div class="card-body">Since the introduction of the Java NIO API&apos;s with Java 4, developers have access to modern operating system facilities to perform asynchronous IO. Using these facilities it is possible to write networking application that that serve thousands of connected clients efficiently. Unfortunately, the NIO API&apos;s are quite low level and require a fair share of boilerplate to get started.<br><br>In this presentation, I will introduce the Netty framework and how its architecture helps you as a developer stay focused on the interesting parts of your network application. At the end of the presentation I will give some real world examples and show how we use Netty in the architecture of our mobile messaging platform XMS.</div>
+        </div>
+        <div class="card mb-3 shadow-sm rounded">
+            <div class="card-header">
+                <h5 class="card-title">Opening - Bert Ertman</h5>
+            </div>
+            <div class="card-body">De openingssessie van de conferentie met aandacht voor de dag zelf en nieuws vanuit de NLJUG. De sessie wordt gepresenteerd door Bert Ertman.</div>
+        </div>
+        <div class="card mb-3 shadow-sm rounded">
+            <div class="card-header">
+                <h5 class="card-title">Keynote door ING - Amir Arroni</h5>
+            </div>
+            <div class="card-body">Keynote van ING, gepresenteerd door Amir Arooni en Peter Jacobs.</div>
+        </div>
+        <div class="card mb-3 shadow-sm rounded">
+            <div class="card-header">
+                <h5 class="card-title">Keynote door Oracle - Sharat Chander</h5>
+            </div>
+            <div class="card-body">Keynote van Oracle, gepresenteerd door Sharat Chander.</div>
+        </div>
+        <div class="card mb-3 shadow-sm rounded">
+            <div class="card-header">
+                <h5 class="card-title">Reactieve applicaties ? klaar voor te toekomst - Allard Buijze</h5>
+            </div>
+            <div class="card-body">De technische eisen aan webapplicaties veranderen in hoog tempo. Enkele jaren geleden nog gebruikten de grootere applicaties enkele tientallen servers en werden response tijden van een seconde en onderhoudsvensters van enkele uren nog geaccepteerd. Tegenwoordig moeten applicaties 100% beschikbaar zijn, terwijl de gebruiker in enkele milliseconden antwoord wil krijgen. Om pieken in gebruik op te kunnen vangen moeten de applicaties op duizenden processoren in een cloud omgeving kunnen draaien.<br><br>De tekortkomingen van de huidige standaard architectuurprincipes kunnen worden opgevangen door een zogenaamde &#8220;reactive architecture&#8221;. Reactieve applicaties bezitten een aantal eigenschappen waardoor ze beter kunnen omgaan met opschalen, bestand zijn tegen fouten en bovendien efficienter gebruik maken van beschikbare server-bronnen.<br><br>In deze presentatie laat Allard zien hoe deze eigenschappen gerealiseerd kunnen worden en welke reeds bekende architectuurpatronen en frameworks hieraan een bijdrage leveren.</div>
+        </div>
+        <div class="card mb-3 shadow-sm rounded">
+            <div class="card-header">
+                <h5 class="card-title">HTML 5 Geolocation + WebSockets + Scalable JavaEE Backend === Awesome Realtime Location Aware Applications - Shekhar Gulati</h5>
+            </div>
+            <div class="card-body">Location Aware apps are everywhere and we use them heavily in our day to day life. You have seen the stuff that Foursquare has done with spatial and you want some of that hotness for your app. But, where to start? In this session, we will build a location aware app using HTML 5 on the client and scalable JavaEE + MongoDB on the server side. HTML 5 GeoLocation API help us to find user current location and MongoDB offers Geospatial indexing support which provides an easy way to get started and enables a variety of location-based applications - ranging from field resource management to social check-ins. Next we will add realtime capabilities to our application using Pusher. Pusher provides scalable WebSockets as a service. The Java EE 6 backend will be built using couple of Java EE 6 technologies -- JAXRS and CDI. Finally , we will deploy our Java EE application on OpenShift -- Red Hat&apos;s public, scalable Platform as a Service.</div>
+        </div>
+        <div class="card mb-3 shadow-sm rounded">
+            <div class="card-header">
+                <h5 class="card-title">Retro Gaming with Lambdas - Stephen Chin</h5>
+            </div>
+            <div class="card-body">Lambda expressions are coming in Java 8 and dramatically change the programming model.  They allow new functional programming patterns that were not possible before, increasing the expressiveness and power of the Java language.<br><br>In this university session, you will learn how to take advantage of the new lambda-enabled Java 8 APIs by building out a retro video game in JavaFX.<br><br>Some of the Java 8 features you will learn about include enhanced collections, functional interfaces, simplified event handlers, and the new stream API.  Start using these in your application today leveraging the latest OpenJDK builds so you can prepare for the future Java 8 release.</div>
+        </div>
+        <div class="card mb-3 shadow-sm rounded">
+            <div class="card-header">
+                <h5 class="card-title">Data Science with R for Java Developers - Sander Mak</h5>
+            </div>
+            <div class="card-body">Understanding data is increasingly important to create cutting-edge applications. A whole new data science field is emerging, with the open source R language as a leading technology. This statistical programming language is specifically designed for analyzing and understanding data.<br><br>In this session we approach R from the perspective of Java developers. How do you get up to speed quickly, what are the pitfalls to look out for?  Also we discuss how to bridge the divide between the R language and the JVM. After this session you can use your new skills to explore an exciting world of data analytics and machine learning! </div>
+        </div>
+    </div>
+
+    <script src="/webjars/jquery/3.1.1/jquery.min.js"></script>
+    <script src="/webjars/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+
+
+</body>
+</html>


### PR DESCRIPTION
To run `spring-comparing-template-engines` with JMH on you local machine just run:

```
mvn clean install
```

And then:
```
java -cp target\template-engines.jar;target\classes org.openjdk.jmh.Main -f 1 -r 5 -w 5 -i 4 -wi 4
```

NOTICE use `:` or`;` as classpath separator depending on whether you are in linux or windows.

There is an issue with `maven-shade-plugin` configured according to JMH that is not including this project's classes (`com.jeroenreijn.examples`) in the resulting `jar`, i.e. `template-engines.jar`. That's why I am providing the `jar` and the `target\classes` in `classpath`. Otherwise, it would be possible to run with `java -jar target\template-engines.jar`.

Usually I run JMH with `-f 1 -r 5 -w 5 -i 4 -wi 4` which is fair enough to collect consistent results. Yet, you may change it accordingly:
* `-f` - How many times to fork a single benchmark.
*  `-r` - Minimum time to spend at each **measurement** iteration in seconds.
*  `-w` - Minimum time to spend at each **warmup** iteration in seconds
* `-i` - Number of measurement iterations
* `-wi` - Number of warmup iterations

**NOTICE** We have here 18 templates correctly measured, missing only JSP which does not produce HTML output because Spring MVC Test doesn't run that servlet container (https://stackoverflow.com/a/37749746/1140754)

Next, you have the results collected in my machine (Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz, Windows 10 Pro, JDK 17.0.2, Java HotSpot(TM) 64-Bit Server VM):

```
Benchmark                        Mode  Cnt      Score       Error  Units
LaunchJMH.benchmarkChunk        thrpt    4   7005,888 ±   662,273  ops/s
LaunchJMH.benchmarkFreemarker   thrpt    4   7874,883 ±   531,991  ops/s
LaunchJMH.benchmarkGroovy       thrpt    4     10,680 ±    14,304  ops/s
LaunchJMH.benchmarkHandlebars   thrpt    4    515,719 ±    62,625  ops/s
LaunchJMH.benchmarkHtmlFlow     thrpt    4  18042,021 ±  8619,886  ops/s
LaunchJMH.benchmarkHttl         thrpt    4   1347,726 ±  1252,651  ops/s
LaunchJMH.benchmarkIckenham     thrpt    4   2996,950 ±   682,017  ops/s
LaunchJMH.benchmarkJade         thrpt    4     72,926 ±    12,907  ops/s
LaunchJMH.benchmarkJsp          thrpt    4  32665,717 ± 29053,124  ops/s
LaunchJMH.benchmarkKotlinxHtml  thrpt    4  13283,696 ±  1150,034  ops/s
LaunchJMH.benchmarkLiqp         thrpt    4   1588,033 ±    83,760  ops/s
LaunchJMH.benchmarkMustache     thrpt    4   4331,608 ±   231,817  ops/s
LaunchJMH.benchmarkPebble       thrpt    4   2192,795 ±    80,917  ops/s
LaunchJMH.benchmarkRocker       thrpt    4  16590,245 ±   987,612  ops/s
LaunchJMH.benchmarkRythm        thrpt    4   7196,728 ±   403,504  ops/s
LaunchJMH.benchmarkScalate      thrpt    4    702,525 ±   348,521  ops/s
LaunchJMH.benchmarkThymeleaf    thrpt    4   1714,108 ±   184,021  ops/s
LaunchJMH.benchmarkTrimou       thrpt    4   9303,166 ±  1352,217  ops/s
LaunchJMH.benchmarkVelocity     thrpt    4   1645,852 ±   169,948  ops/s
```