### PR TITLE
Updated bootstrap from 4.3.1 to 5.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,21 @@ This is a demo project, which accompanied my ["Shoot-out! Template engines for t
 * [Velocity](http://velocity.apache.org/) - v1.7
 * [Velocity Tools](http://velocity.apache.org/tools/) - v2.0
 * [Thymeleaf](http://www.thymeleaf.org/) - v3.0.11.RELEASE
-* Mustache - Based on [JMustache](https://github.com/samskivert/jmustache) - v1.14
-* [Scalate](http://scalate.fusesource.org/)  - v1.9.3
-* [Jade4j](https://github.com/neuland/jade4j) - v1.2.7
+* Mustache - Based on [JMustache](https://github.com/samskivert/jmustache) - v1.15
+* [Scalate](http://scalate.fusesource.org/)  - v1.9.8
+* [Jade4j](https://github.com/neuland/jade4j) - v1.3.1
 * [HTTL](http://httl.github.io/en/) - v1.0.11
-* [Pebble](https://pebbletemplates.io/) - v3.0.7
-* [Handlebars](http://jknack.github.io/handlebars.java/) - v4.1.2
-* [chunk](http://www.x5software.com/chunk/) - v3.5.0
-* [HtmlFlow](https://github.com/xmlet/HtmlFlow/) - v3.5
-* [Trimou](http://trimou.org/) - v2.5.0.Final
+* [Pebble](https://pebbletemplates.io/) - v3.1.6
+* [Handlebars](http://jknack.github.io/handlebars.java/) - v4.3.1
+* [chunk](http://www.x5software.com/chunk/) - v3.6.2
+* [HtmlFlow](https://github.com/xmlet/HtmlFlow/) - v4.0
+* [Trimou](http://trimou.org/) - v2.5.1.Final
 * [Rocker](https://github.com/fizzed/rocker/) - v1.2.1
-* [Ickenham](https://github.com/enpassant/ickenham) - v1.4.1
-* [Rythm](http://rythmengine.org/) - v1.3.0
+* [Ickenham](https://github.com/enpassant/ickenham) - v1.5.0
+* [Rythm](http://rythmengine.org/) - v1.4.1
 * [Groovy Templates](https://groovy.apache.org/) - v2.5.6
-* [Liqp - Jekyll](https://github.com/bkiers/Liqp) - v0.7.9
-* [kolinx.html](https://github.com/Kotlin/kotlinx.html) - v7.1
+* [Liqp - Jekyll](https://github.com/bkiers/Liqp) - v0.8.5.1
+* [kolinx.html](https://github.com/Kotlin/kotlinx.html) - v1.7.20
 
 ## Build and run
 You need Java 8 and Maven 3 to build and run this project.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.jeroenreijn</groupId>
     <artifactId>spring-comparing-template-engines</artifactId>
     <packaging>war</packaging>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.9.1-SNAPSHOT</version>
     <name>template-engines</name>
 
     <properties>
@@ -13,8 +13,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
-        <jquery.version>3.6.1</jquery.version>
-        <bootstrap.version>4.3.1</bootstrap.version>
+        <bootstrap.version>5.2.3</bootstrap.version>
 
         <!-- Template engine versions -->
         <thymeleaf.version>3.0.11.RELEASE</thymeleaf.version>
@@ -29,7 +28,7 @@
         <mustache-spring-view.version>1.4</mustache-spring-view.version>
         <mustache-java.version>0.9.5</mustache-java.version>
         <pebble.version>3.1.6</pebble.version>
-        <scala.version>2.12</scala.version>
+        <scala.version>2.13</scala.version>
         <scalate-core.version>1.9.8</scalate-core.version>
         <htmlflow.version>4.0</htmlflow.version>
         <trimou.version>2.5.1.Final</trimou.version>
@@ -37,7 +36,7 @@
         <ickenham-springmvc.version>1.5.0</ickenham-springmvc.version>
         <rythm.version>1.4.1</rythm.version>
         <rythm-spring.version>1.2.2</rythm-spring.version>
-        <liqp.version>0.8.5.0</liqp.version>
+        <liqp.version>0.8.5.1</liqp.version>
         <kotlin.version>1.7.20</kotlin.version>
         <kotlinx.html.version>0.8.0</kotlinx.html.version>
     </properties>
@@ -77,12 +76,6 @@
             <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
             <version>${bootstrap.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>jquery</artifactId>
-            <version>${jquery.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/jeroenreijn/examples/configuration/WebMvcConfig.java
+++ b/src/main/java/com/jeroenreijn/examples/configuration/WebMvcConfig.java
@@ -283,7 +283,7 @@ public class WebMvcConfig implements ApplicationContextAware, WebMvcConfigurer {
 
 	@Bean
 	public LiqpViewResolver liqpViewResolver() {
-		LiqpViewResolver viewResolver = new LiqpViewResolver(applicationContext.getBean(MessageSource.class));
+		LiqpViewResolver viewResolver = new LiqpViewResolver();
 		viewResolver.setViewClass(LiqpView.class);
 		viewResolver.setPrefix("classpath:./templates/liqp/");
 		viewResolver.setSuffix(".liqp");

--- a/src/main/java/com/jeroenreijn/examples/model/Presentation.java
+++ b/src/main/java/com/jeroenreijn/examples/model/Presentation.java
@@ -1,5 +1,7 @@
 package com.jeroenreijn.examples.model;
 
+import liqp.parser.Inspectable;
+
 import java.util.Date;
 
 /**
@@ -7,7 +9,7 @@ import java.util.Date;
  *
  * @author Jeroen Reijn
  */
-public class Presentation {
+public class Presentation implements Inspectable {
 	private Long id;
 	private String title;
 	private String speakerName;

--- a/src/main/java/com/jeroenreijn/examples/model/i18nLayout.java
+++ b/src/main/java/com/jeroenreijn/examples/model/i18nLayout.java
@@ -1,15 +1,13 @@
 package com.jeroenreijn.examples.model;
 
-import java.io.IOException;
-import java.io.Writer;
-
-import javax.servlet.http.HttpServletRequest;
-
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template.Fragment;
 import org.springframework.context.MessageSource;
 import org.springframework.web.servlet.LocaleResolver;
 
-import com.samskivert.mustache.Mustache;
-import com.samskivert.mustache.Template.Fragment;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.io.Writer;
 
 public class i18nLayout implements Mustache.Lambda {
 	private HttpServletRequest request;
@@ -23,9 +21,7 @@ public class i18nLayout implements Mustache.Lambda {
 	}
 
 	public String message(String key) {
-		String text = messageSource.getMessage(key, null, localeResolver.resolveLocale(request));
-
-		return text;
+		return messageSource.getMessage(key, null, localeResolver.resolveLocale(request));
 	}
 
 	@Override

--- a/src/main/java/com/jeroenreijn/examples/view/HtmlFlowIndexView.java
+++ b/src/main/java/com/jeroenreijn/examples/view/HtmlFlowIndexView.java
@@ -29,7 +29,7 @@ public class HtmlFlowIndexView {
 					.title().text("JFall 2013 Presentations - HtmlFlow").__()
 					.link()
 						.attrRel(EnumRelType.STYLESHEET)
-						.attrHref("/webjars/bootstrap/4.3.1/css/bootstrap.min.css")
+						.attrHref("/webjars/bootstrap/5.2.3/css/bootstrap.min.css")
 						.attrMedia(EnumMediaType.SCREEN)
 					.__() // link
 				.__() // head
@@ -60,8 +60,7 @@ public class HtmlFlowIndexView {
 									)
 						)
 					.__() // container
-				.script().attrSrc("/webjars/jquery/3.1.1/jquery.min.js").__()
-				.script().attrSrc("/webjars/bootstrap/4.3.1/js/bootstrap.min.js").__()
+				.script().attrSrc("/webjars/bootstrap/5.2.3/js/bootstrap.min.js").__()
 				.__() // body
 			.__(); // html
 	}

--- a/src/main/java/com/jeroenreijn/examples/view/KotlinxHtmlIndexView.kt
+++ b/src/main/java/com/jeroenreijn/examples/view/KotlinxHtmlIndexView.kt
@@ -17,7 +17,7 @@ class KotlinxHtmlIndexView {
                             meta {name = "viewport"; content = "width=device-width, initial-scale=1.0" }
                             meta {httpEquiv=MetaHttpEquiv.contentLanguage; content="IE=Edge" }
                             title { text("JFall 2013 Presentations - htmlApi")}
-                            link {rel=LinkRel.stylesheet; href="/webjars/bootstrap/4.3.1/css/bootstrap.min.css"; media = LinkMedia.screen;}
+                            link {rel=LinkRel.stylesheet; href="/webjars/bootstrap/5.2.3/css/bootstrap.min.css"; media = LinkMedia.screen;}
                         }
                         body {
                             div {
@@ -32,7 +32,7 @@ class KotlinxHtmlIndexView {
                                         classes = setOf("card mb-3 shadow-sm rounded")
                                         div {
                                             classes = setOf("card-header")
-                                            h3 {
+                                            h5 {
                                                 classes = setOf("card-title")
                                                 text( it.title + " - " + it.speakerName)
                                             }
@@ -45,8 +45,7 @@ class KotlinxHtmlIndexView {
                                 }
                             }
 
-                            script { src = "/webjars/jquery/3.1.1/jquery.min.js" }
-                            script { src = "/webjars/bootstrap/4.3.1/js/bootstrap.min.js" }
+                            script { src = "/webjars/bootstrap/5.2.3/js/bootstrap.min.js" }
                         }
                     }
             return output.toString()

--- a/src/main/java/com/jeroenreijn/examples/view/LiqpView.java
+++ b/src/main/java/com/jeroenreijn/examples/view/LiqpView.java
@@ -1,6 +1,10 @@
 package com.jeroenreijn.examples.view;
 
-import liqp.Template;
+import com.jeroenreijn.examples.model.i18nLayout;
+import liqp.ParseSettings;
+import liqp.TemplateContext;
+import liqp.TemplateParser;
+import liqp.filters.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.ResourceUtils;
@@ -15,20 +19,47 @@ import java.util.Map;
 public class LiqpView extends AbstractTemplateView {
 	private static final Logger LOGGER = LoggerFactory.getLogger(LiqpView.class);
 
+	public LiqpView() {
+		/*
+		TemplateParser.Builder builder = new TemplateParser.Builder();
+		builder.build().getParseSettings().flavor.getFilters().mergeWith(Filters.of(new Filter("i18n") {
+			@Override
+			public Object apply(Object value, Object... params) {
+				return messageSource.getMessage(value.toString(), null, Locale.ENGLISH);
+			}
+})         ); */
+	}
+
 	@Override
 	protected void renderMergedTemplateModel(Map<String, Object> model, HttpServletRequest request, HttpServletResponse response) throws Exception {
 		String templateUrl = this.getUrl();
 		File templateFile = ResourceUtils.getFile(templateUrl);
+		//TemplateParser parser = new TemplateParser.Builder()
+
 		if (templateFile.exists()) {
 			// Liqp serializes the entire "model" to JSON Object and then to Map. This fails for custom and Spring classes
 			model.remove("springMacroRequestContext");
 			model.remove("org.springframework.validation.BindingResult.i18n");
-			model.remove("i18n");
 
 			// Just in case, we need it as in all other view resolvers
 			model.put("contextPath", request.getContextPath());
 
-			String rendered = Template.parse(templateFile).render(model);
+			ParseSettings parseSettings = new ParseSettings.Builder()
+					.with(ParseSettings.DEFAULT)
+					.with(new Filter("i18n") {
+						@Override
+						public Object apply(Object value, TemplateContext context, Object... params) {
+							i18nLayout i18n = (i18nLayout) context.getVariables().get("i18n");
+							return (value == null ? "" : i18n.message(value.toString()));
+						}
+					})
+					.build();
+
+			TemplateParser builder = new TemplateParser.Builder()
+					.withParseSettings(parseSettings)
+					.build();
+
+			String rendered = builder.parse(templateFile).render(model);
 			response.getWriter().write(rendered);
 		} else {
 			LOGGER.error("Template not found: {}", templateUrl);

--- a/src/main/java/com/jeroenreijn/examples/view/LiqpViewResolver.java
+++ b/src/main/java/com/jeroenreijn/examples/view/LiqpViewResolver.java
@@ -1,21 +1,11 @@
 package com.jeroenreijn.examples.view;
 
-import liqp.filters.Filter;
-import org.springframework.context.MessageSource;
 import org.springframework.web.servlet.view.AbstractTemplateViewResolver;
 
-import java.util.Locale;
-
 public class LiqpViewResolver extends AbstractTemplateViewResolver {
-	public LiqpViewResolver(MessageSource messageSource) {
-		this.setViewClass(this.requiredViewClass());
 
-		Filter.registerFilter(new Filter("i18n") {
-			@Override
-			public Object apply(Object value, Object... params) {
-				return messageSource.getMessage(value.toString(), null, Locale.ENGLISH);
-			}
-		});
+	public LiqpViewResolver() {
+		this.setViewClass(this.requiredViewClass());
 	}
 
 	@Override

--- a/src/main/resources/templates/freemarker/includes.ftl
+++ b/src/main/resources/templates/freemarker/includes.ftl
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
   <title>[@spring.message code="example.title"/] - Freemarker</title>
-  <link rel="stylesheet" href="${springMacroRequestContext.getContextPath()}/webjars/bootstrap/4.3.1/css/bootstrap.min.css" media="screen" />
+  <link rel="stylesheet" href="${springMacroRequestContext.getContextPath()}/webjars/bootstrap/5.2.3/css/bootstrap.min.css" media="screen" />
 </head>
 [/#macro]
 
@@ -16,6 +16,5 @@
 [/#macro]
 
 [#macro scripts]
-<script src="${springMacroRequestContext.getContextPath()}/webjars/jquery/3.1.1/jquery.min.js"></script>
-<script src="${springMacroRequestContext.getContextPath()}/webjars/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+<script src="${springMacroRequestContext.getContextPath()}/webjars/bootstrap/5.2.3/js/bootstrap.min.js"></script>
 [/#macro]

--- a/src/main/resources/templates/groovy/head.tpl
+++ b/src/main/resources/templates/groovy/head.tpl
@@ -3,4 +3,4 @@ meta(name: 'viewport', content: 'width=device-width, initial-scale=1.0')
 meta('http-equiv': 'X-UA-Compatible', 'content': 'IE=Edge')
 title(title)
 
-link(rel:'stylesheet', href:'/webjars/bootstrap/4.3.1/css/bootstrap.min.css', media: 'screen')
+link(rel:'stylesheet', href:'/webjars/bootstrap/5.2.3/css/bootstrap.min.css', media: 'screen')

--- a/src/main/resources/templates/groovy/scripts.tpl
+++ b/src/main/resources/templates/groovy/scripts.tpl
@@ -1,2 +1,1 @@
-script(src: '/webjars/jquery/3.1.1/jquery.min.js') {}
-script(src: '/webjars/bootstrap/4.3.1/js/bootstrap.min.js') {}
+script(src: '/webjars/bootstrap/5.2.3/js/bootstrap.min.js') {}

--- a/src/main/resources/templates/httl/index-httl.httl
+++ b/src/main/resources/templates/httl/index-httl.httl
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
   <title>${"example.title".message} - Httl</title>
-  <link rel="stylesheet" href="${contextPath}/webjars/bootstrap/4.3.1/css/bootstrap.min.css" media="screen"/>
+  <link rel="stylesheet" href="${contextPath}/webjars/bootstrap/5.2.3/css/bootstrap.min.css" media="screen"/>
 </head>
 <body>
 <div class="container">
@@ -24,7 +24,6 @@
     </div>
     <!--#end-->
 </div>
-<script src=${contextPath}/webjars/jquery/3.1.1/jquery.min.js></script>
-<script src=${contextPath}/webjars/bootstrap/4.3.1/js/bootstrap.min.js></script>
+<script src=${contextPath}/webjars/bootstrap/5.2.3/js/bootstrap.min.js></script>
 </body>
 </html>

--- a/src/main/resources/templates/liqp/index-liqp.liqp
+++ b/src/main/resources/templates/liqp/index-liqp.liqp
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
     <title>{{ "example.title" | i18n }} - Liqp</title>
-    <link rel="stylesheet" href="{{contextPath}}/webjars/bootstrap/4.3.1/css/bootstrap.min.css" media="screen"/>
+    <link rel="stylesheet" href="{{contextPath}}/webjars/bootstrap/5.2.3/css/bootstrap.min.css" media="screen"/>
 </head>
 <body>
 <div class="container">
@@ -16,16 +16,15 @@
     {% for presentation in presentations %}
     <div class="card mb-3 shadow-sm rounded">
         <div class="card-header">
-            <h5 class="card-title">{{ presentation.title }} - {{presentation.speakerName }}</h5>
+            <h5 class="card-title">{{ presentation.title }} - {{ presentation.speakerName }}</h5>
         </div>
         <div class="card-body">
-            {{presentation.summary}}
+            {{ presentation.summary }}
         </div>
     </div>
     {% endfor %}
 
 </div>
-<script src="{{contextPath}}/webjars/jquery/3.1.1/jquery.min.js"></script>
-<script src="{{contextPath}}/webjars/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+<script src="{{contextPath}}/webjars/bootstrap/5.2.3/js/bootstrap.min.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/pebble/base.pebble
+++ b/src/main/resources/templates/pebble/base.pebble
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
     <title>{{ i18n("messages","example.title") }} - Pebble</title>
-    <link rel="stylesheet" href="{{rc.contextPath}}/webjars/bootstrap/4.3.1/css/bootstrap.min.css" media="screen"/>
+    <link rel="stylesheet" href="{{rc.contextPath}}/webjars/bootstrap/5.2.3/css/bootstrap.min.css" media="screen"/>
 </head>
 <body>
 <div class="container">
@@ -13,7 +13,6 @@
         {# This section is to be overriden by child templates #}
     {% endblock content %}
 </div>
-<script src="{{rc.contextPath}}/webjars/jquery/3.1.1/jquery.min.js"></script>
-<script src="{{rc.contextPath}}/webjars/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+<script src="{{rc.contextPath}}/webjars/bootstrap/5.2.3/js/bootstrap.min.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/rocker/index.rocker.html
+++ b/src/main/resources/templates/rocker/index.rocker.html
@@ -5,12 +5,11 @@
 @args (Iterable<Presentation> presentations, i18nLayout i18n)
 
 @css => {
-<link rel="stylesheet" href="/webjars/bootstrap/4.3.1/css/bootstrap.min.css" media="screen"/>
+<link rel="stylesheet" href="/webjars/bootstrap/5.2.3/css/bootstrap.min.css" media="screen"/>
 }
 
 @js => {
-<script src="/webjars/jquery/3.1.1/jquery.min.js"></script>
-<script src="/webjars/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+<script src="/webjars/bootstrap/5.2.3/js/bootstrap.min.js"></script>
 }
 
 @base.template(i18n.message("example.title"), css, js) -> {

--- a/src/main/resources/templates/trimou/head.trimou
+++ b/src/main/resources/templates/trimou/head.trimou
@@ -3,5 +3,5 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
     <title>{{springMsg "example.title" "Unknown i18n"}} - Trimou</title>
-    <link rel="stylesheet" href="/webjars/bootstrap/4.3.1/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="/webjars/bootstrap/5.2.3/css/bootstrap.min.css"/>
 </head>

--- a/src/main/resources/templates/trimou/scripts.trimou
+++ b/src/main/resources/templates/trimou/scripts.trimou
@@ -1,2 +1,1 @@
-<script src="/webjars/jquery/3.1.1/jquery.min.js"></script>
-<script src="/webjars/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+<script src="/webjars/bootstrap/5.2.3/js/bootstrap.min.js"></script>

--- a/src/main/resources/templates/velocity/includes.vm
+++ b/src/main/resources/templates/velocity/includes.vm
@@ -4,7 +4,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
     <title>#springMessage("example.title") - Velocity</title>
-    <link rel="stylesheet" href="$link.relative("/webjars/bootstrap/4.3.1/css/bootstrap.min.css")" media="screen" />
+    <link rel="stylesheet" href="$link.relative("/webjars/bootstrap/5.2.3/css/bootstrap.min.css")" media="screen" />
 </head>
 #end
 
@@ -15,6 +15,5 @@
 #end
 
 #macro( scripts )
-<script src="$link.relative("/webjars/jquery/3.1.1/jquery.min.js")"></script>
-<script src="$link.relative("/webjars/bootstrap/4.3.1/js/bootstrap.min.js")"></script>
+<script src="$link.relative("/webjars/bootstrap/5.2.3/js/bootstrap.min.js")"></script>
 #end

--- a/src/main/webapp/WEB-INF/chunk/index-chunk.chtml
+++ b/src/main/webapp/WEB-INF/chunk/index-chunk.chtml
@@ -5,13 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
     <title>{% messages.example.title %} - Chunk</title>
-    <link rel="stylesheet" href="{% $rc.context_path %}/webjars/bootstrap/4.3.1/css/bootstrap.min.css" media="screen"/>
+    <link rel="stylesheet" href="{% $rc.context_path %}/webjars/bootstrap/5.2.3/css/bootstrap.min.css" media="screen"/>
 </head>
 <body>
 <div class="container">
     {% include content %}
 </div>
-<script src="{% $rc.context_path %}/webjars/jquery/3.1.1/jquery.min.js"></script>
-<script src="{% $rc.context_path %}/webjars/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+<script src="{% $rc.context_path %}/webjars/bootstrap/5.2.3/js/bootstrap.min.js"></script>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/handlebars/head.hbs
+++ b/src/main/webapp/WEB-INF/handlebars/head.hbs
@@ -3,5 +3,5 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
     <title>{{i18n "example.title"}} - Handlebars</title>
-    <link rel="stylesheet" href="{{springMacroRequestContext.contextPath}}/webjars/bootstrap/4.3.1/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="{{springMacroRequestContext.contextPath}}/webjars/bootstrap/5.2.3/css/bootstrap.min.css"/>
 </head>

--- a/src/main/webapp/WEB-INF/handlebars/scripts.hbs
+++ b/src/main/webapp/WEB-INF/handlebars/scripts.hbs
@@ -1,2 +1,1 @@
-<script src="{{springMacroRequestContext.contextPath}}/webjars/jquery/3.1.1/jquery.min.js"></script>
-<script src="{{springMacroRequestContext.contextPath}}/webjars/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+<script src="{{springMacroRequestContext.contextPath}}/webjars/bootstrap/5.2.3/js/bootstrap.min.js"></script>

--- a/src/main/webapp/WEB-INF/ickenham/head.hbs
+++ b/src/main/webapp/WEB-INF/ickenham/head.hbs
@@ -3,5 +3,5 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
     <title>{{i18n "example.title"}} - Ickenham</title>
-    <link rel="stylesheet" href="{{rc.contextPath}}/webjars/bootstrap/4.3.1/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="{{rc.contextPath}}/webjars/bootstrap/5.2.3/css/bootstrap.min.css"/>
 </head>

--- a/src/main/webapp/WEB-INF/ickenham/scripts.hbs
+++ b/src/main/webapp/WEB-INF/ickenham/scripts.hbs
@@ -1,2 +1,1 @@
-<script src="{{rc.contextPath}}/webjars/jquery/3.1.1/jquery.min.js"></script>
-<script src="{{rc.contextPath}}/webjars/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+<script src="{{rc.contextPath}}/webjars/bootstrap/5.2.3/js/bootstrap.min.js"></script>

--- a/src/main/webapp/WEB-INF/jade/layout.jade
+++ b/src/main/webapp/WEB-INF/jade/layout.jade
@@ -3,12 +3,11 @@ html
   head
     meta(name="charset", content="UTF-8")
     title #{i18n.message("example.title")} - Jade4j
-    link(rel="stylesheet", href=springMacroRequestContext.contextPath + "/webjars/bootstrap/4.3.1/css/bootstrap.min.css")
+    link(rel="stylesheet", href=springMacroRequestContext.contextPath + "/webjars/bootstrap/5.2.3/css/bootstrap.min.css")
     meta(name="viewport", content="width=device-width, initial-scale=1.0")
   body
     .container
         .pb-2.mt-4.mb-3.border-bottom
             h1 #{i18n.message("example.title")} - Jade4j
         block content
-    script(src=springMacroRequestContext.contextPath + "/webjars/jquery/3.1.1/jquery.min.js")
-    script(src=springMacroRequestContext.contextPath + "/webjars/bootstrap/4.3.1/js/bootstrap.min.js")
+    script(src=springMacroRequestContext.contextPath + "/webjars/bootstrap/5.2.3/js/bootstrap.min.js")

--- a/src/main/webapp/WEB-INF/jsp/head.jspf
+++ b/src/main/webapp/WEB-INF/jsp/head.jspf
@@ -3,5 +3,5 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
   <title><spring:message code="example.title"/> - JSP</title>
-  <link rel="stylesheet" href="<c:url value='/webjars/bootstrap/4.3.1/css/bootstrap.min.css'/>" media="screen"/>
+  <link rel="stylesheet" href="<c:url value='/webjars/bootstrap/5.2.3/css/bootstrap.min.css'/>" media="screen"/>
 </head>

--- a/src/main/webapp/WEB-INF/jsp/scripts.jspf
+++ b/src/main/webapp/WEB-INF/jsp/scripts.jspf
@@ -1,2 +1,1 @@
-<script src="<c:url value='/webjars/jquery/3.1.1/jquery.min.js'/>"></script>
-<script src="<c:url value='/webjars/bootstrap/4.3.1/js/bootstrap.min.js'/>"></script>
+<script src="<c:url value='/webjars/bootstrap/5.2.3/js/bootstrap.min.js'/>"></script>

--- a/src/main/webapp/WEB-INF/mustache/head.mustache
+++ b/src/main/webapp/WEB-INF/mustache/head.mustache
@@ -3,5 +3,5 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
     <title>{{#i18n}}example.title{{/i18n}} - Mustache</title>
-    <link rel="stylesheet" href="{{rc.contextPath}}/webjars/bootstrap/4.3.1/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="{{rc.contextPath}}/webjars/bootstrap/5.2.3/css/bootstrap.min.css"/>
 </head>

--- a/src/main/webapp/WEB-INF/mustache/scripts.mustache
+++ b/src/main/webapp/WEB-INF/mustache/scripts.mustache
@@ -1,2 +1,1 @@
-<script src="{{rc.contextPath}}/webjars/jquery/3.1.1/jquery.min.js"></script>
-<script src="{{rc.contextPath}}/webjars/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+<script src="{{rc.contextPath}}/webjars/bootstrap/5.2.3/js/bootstrap.min.js"></script>

--- a/src/main/webapp/WEB-INF/rythm/layout.html
+++ b/src/main/webapp/WEB-INF/rythm/layout.html
@@ -5,13 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
     <title>@i18n("example.title") - Rythm</title>
-    <link rel="stylesheet" href="/webjars/bootstrap/4.3.1/css/bootstrap.min.css" media="screen"/>
+    <link rel="stylesheet" href="/webjars/bootstrap/5.2.3/css/bootstrap.min.css" media="screen"/>
 </head>
 <body>
 <div class="container">
 @render()
 </div>
-<script src="/webjars/jquery/3.1.1/jquery.min.js"></script>
-<script src="/webjars/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+<script src="/webjars/bootstrap/5.2.3/js/bootstrap.min.js"></script>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/scalate/head.scaml
+++ b/src/main/webapp/WEB-INF/scalate/head.scaml
@@ -4,4 +4,4 @@
     %meta(name="viewport" content="width=device-width, initial-scale=1.0")
     %meta(http-equiv="X-UA-Compatible" content="IE=Edge")
     %title= title
-    %link(rel="stylesheet" href="#{context.contextPath}/webjars/bootstrap/4.3.1/css/bootstrap.min.css" media="screen")
+    %link(rel="stylesheet" href="#{context.contextPath}/webjars/bootstrap/5.2.3/css/bootstrap.min.css" media="screen")

--- a/src/main/webapp/WEB-INF/scalate/scripts.scaml
+++ b/src/main/webapp/WEB-INF/scalate/scripts.scaml
@@ -1,2 +1,1 @@
-%script(src="#{context.contextPath}/webjars/jquery/3.1.1/jquery.min.js")
-%script(src="#{context.contextPath}/webjars/bootstrap/4.3.1/js/bootstrap.min.js")
+%script(src="#{context.contextPath}/webjars/bootstrap/5.2.3/js/bootstrap.min.js")

--- a/src/main/webapp/WEB-INF/thymeleaf/includes.html
+++ b/src/main/webapp/WEB-INF/thymeleaf/includes.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
     <title th:text="#{example.title} + ' - Thymeleaf'">Title</title>
-    <link rel="stylesheet" th:href="@{/webjars/bootstrap/4.3.1/css/bootstrap.min.css}"/>
+    <link rel="stylesheet" th:href="@{/webjars/bootstrap/5.2.3/css/bootstrap.min.css}"/>
 </head>
 
 <body>
@@ -14,8 +14,7 @@
 </div>
 
 <section th:fragment="scripts" th:remove="tag">
-    <script th:src="@{/webjars/jquery/3.1.1/jquery.min.js}"></script>
-    <script th:src="@{/webjars/bootstrap/4.3.1/js/bootstrap.min.js}"></script>
+    <script th:src="@{/webjars/bootstrap/5.2.3/js/bootstrap.min.js}"></script>
 </section>
 
 </body>

--- a/src/main/webapp/WEB-INF/thymeleaf/index-thymeleaf.html
+++ b/src/main/webapp/WEB-INF/thymeleaf/index-thymeleaf.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head th:replace="includes :: head">
-    <link rel="stylesheet" th:href="@{/webjars/bootstrap/4.3.1/css/bootstrap.min.css}"/>
+    <link rel="stylesheet" th:href="@{/webjars/bootstrap/5.2.3/css/bootstrap.min.css}"/>
 </head>
 <body>
 <div class="container">
@@ -13,7 +13,6 @@
         <div class="card-body" th:utext="${item.summary}">Summary</div>
     </div>
 </div>
-<script th:src="@{/webjars/jquery/3.1.1/jquery.min.js}" th:replace="includes :: scripts"></script>
 <script th:remove="all" type="text/javascript" th:src="@{/static/js/thymol.js}"></script>
 </body>
 </html>


### PR DESCRIPTION
* Fixed Liqp (because, it required "inspection" now). Had to rewrite bunch of code, because of deprecated API.
* Removed jQuery everywhere
* Updated README.md to reflect the actual versions
* Updated pom.xml
* Updated some libraries.

Fixed PR #91
p.s. Bootstrap doesn't use jQuery anymore. That's why #91 is dangerous to accept blindly.